### PR TITLE
Remove KubeArchive CLI fallback instructions from tool docstrings

### DIFF
--- a/src/server-mcp.py
+++ b/src/server-mcp.py
@@ -1358,15 +1358,6 @@ async def get_pipelinerun_logs(
 
     Prioritizes failed pods and manages token budgets automatically when no time/line filters specified.
 
-    IMPORTANT: If this tool returns "No pods found", the pods may have been garbage collected by Kubernetes.
-    In that case, use KubeArchive to retrieve archived logs via Bash commands:
-
-    1. Discover KubeArchive endpoint:
-       kubectl get routes -A -o jsonpath='{range .items[*]}{.spec.host}{"\\n"}{end}' | grep kubearchive
-
-    2. Retrieve archived logs:
-       kubectl ka logs pipelineruns/<pipelinerun_name> -n <namespace> --host https://<kubearchive-host>
-
     Args:
         pipelinerun_name: PipelineRun name.
         namespace: Kubernetes namespace.
@@ -1380,7 +1371,7 @@ async def get_pipelinerun_logs(
 
     Returns:
         Dict[str, Any]: Pod names as keys, logs as values. Includes "_metadata" with processing info.
-        Returns {"info": "No pods found..."} if pods are garbage collected - use KubeArchive fallback.
+        Returns {"info": "No pods found..."} if pods are garbage collected - use query_kubearchive tool.
     """
     # Build log filtering info for logging
     filter_info = []
@@ -2715,14 +2706,6 @@ async def analyze_failed_pipeline(namespace: str, pipeline_run: str) -> Dict[str
     Perform root cause analysis on a failed Tekton PipelineRun.
 
     Fetches pipeline/task details, analyzes logs for errors, and provides remediation recommendations.
-
-    NOTE: If logs are unavailable due to pod garbage collection, use KubeArchive to retrieve archived logs:
-
-    1. Discover KubeArchive endpoint:
-       kubectl get routes -A -o jsonpath='{range .items[*]}{.spec.host}{"\\n"}{end}' | grep kubearchive
-
-    2. Retrieve archived logs:
-       kubectl ka logs pipelineruns/<pipeline_run> -n <namespace> --host https://<kubearchive-host>
 
     Args:
         namespace: Kubernetes namespace of the PipelineRun.
@@ -7987,14 +7970,6 @@ async def automated_triage_rca_report_generator(
 
     Performs log analysis, resource checks, event correlation, and provides remediation suggestions.
 
-    NOTE: If logs are unavailable due to pod garbage collection, use KubeArchive to retrieve archived logs:
-
-    1. Discover KubeArchive endpoint:
-       kubectl get routes -A -o jsonpath='{range .items[*]}{.spec.host}{"\\n"}{end}' | grep kubearchive
-
-    2. Retrieve archived logs:
-       kubectl ka logs pipelineruns/<failure_identifier> -n <namespace> --host https://<kubearchive-host>
-
     Args:
         failure_identifier: Pipeline run name, pod name, or failure event ID.
         namespace: Optional namespace where the failure occurred. If not provided, searches across detected CI/CD namespaces.
@@ -8064,7 +8039,7 @@ async def automated_triage_rca_report_generator(
                 "immediate_actions": [
                     f"Verify the resource name '{failure_identifier}' is correct",
                     "The resource may have been garbage collected by Tekton pruner",
-                    "Try using KubeArchive to retrieve archived logs: kubectl ka logs pipelineruns/<name> -n <namespace> --host https://<kubearchive-host>",
+                    "Try using the query_kubearchive tool to retrieve archived logs",
                     "Check if there are related events: kubectl get events -n <namespace> --field-selector involvedObject.name=<name>",
                 ],
                 "preventive_measures": [


### PR DESCRIPTION
## Summary
- Removed inline KubeArchive CLI instructions (`kubectl ka logs ...`) from `get_pipelinerun_logs`, `analyze_failed_pipeline`, and `automated_triage_rca_report_generator` docstrings
- Updated references to point to the dedicated `query_kubearchive` MCP tool instead
- These instructions were redundant after the `query_kubearchive` tool was added in #40

## Test plan
- [ ] Verify MCP server starts without errors
- [ ] Confirm `query_kubearchive` tool is available and functional
- [ ] Check that `get_pipelinerun_logs`, `analyze_failed_pipeline`, and `automated_triage_rca_report_generator` tool descriptions no longer show CLI instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)