### PR TITLE
fix: add async lock to list_namespaces cache

### DIFF
--- a/src/server-mcp.py
+++ b/src/server-mcp.py
@@ -397,6 +397,7 @@ _prometheus_endpoint_cache = PrometheusEndpointCache()
 
 # Namespace cache for avoiding repeated API calls
 _namespace_cache = {"namespaces": None, "timestamp": 0}
+_namespace_cache_lock = asyncio.Lock()
 _NAMESPACE_CACHE_TTL = 86400  # 1 day in seconds
 
 
@@ -616,37 +617,41 @@ async def list_namespaces() -> List[str]:
     Returns:
         List[str]: Alphabetically sorted namespace names. Empty list if access denied or cluster unreachable.
     """
-    global _namespace_cache
-
     current_time = time.time()
     if (_namespace_cache["namespaces"] is not None and
             current_time - _namespace_cache["timestamp"] < _NAMESPACE_CACHE_TTL):
         logger.debug("Returning cached namespace list")
         return _namespace_cache["namespaces"]
 
-    try:
-        logger.info("Retrieving all namespaces from Kubernetes cluster")
-        namespaces = k8s_core_api.list_namespace()
-        ns_names = sorted([ns.metadata.name for ns in namespaces.items if ns.metadata and ns.metadata.name])
+    async with _namespace_cache_lock:
+        current_time = time.time()
+        if (_namespace_cache["namespaces"] is not None and
+                current_time - _namespace_cache["timestamp"] < _NAMESPACE_CACHE_TTL):
+            return _namespace_cache["namespaces"]
 
-        _namespace_cache["namespaces"] = ns_names
-        _namespace_cache["timestamp"] = current_time
+        try:
+            logger.info("Retrieving all namespaces from Kubernetes cluster")
+            namespaces = k8s_core_api.list_namespace()
+            ns_names = sorted([ns.metadata.name for ns in namespaces.items if ns.metadata and ns.metadata.name])
 
-        logger.info(f"Successfully retrieved {len(ns_names)} namespaces")
-        return ns_names
+            _namespace_cache["namespaces"] = ns_names
+            _namespace_cache["timestamp"] = current_time
 
-    except ApiException as e:
-        if e.status == 403:
-            logger.warning(f"Insufficient permissions to list namespaces: {e.reason}. Check RBAC configuration.")
-        elif e.status == 401:
-            logger.error(f"Authentication failed while listing namespaces: {e.reason}. Check kubeconfig.")
-        else:
-            logger.error(f"API error while listing namespaces: {e.status} - {e.reason}")
-        return []
+            logger.info(f"Successfully retrieved {len(ns_names)} namespaces")
+            return ns_names
 
-    except Exception as e:
-        logger.error(f"Unexpected error while listing namespaces: {str(e)}", exc_info=True)
-        return []
+        except ApiException as e:
+            if e.status == 403:
+                logger.warning(f"Insufficient permissions to list namespaces: {e.reason}. Check RBAC configuration.")
+            elif e.status == 401:
+                logger.error(f"Authentication failed while listing namespaces: {e.reason}. Check kubeconfig.")
+            else:
+                logger.error(f"API error while listing namespaces: {e.status} - {e.reason}")
+            return []
+
+        except Exception as e:
+            logger.error(f"Unexpected error while listing namespaces: {str(e)}", exc_info=True)
+            return []
 
 
 async def detect_tekton_namespaces() -> Dict[str, List[str]]:


### PR DESCRIPTION
## Problem

`list_namespaces()` accesses the shared `_namespace_cache` dict without any lock. Concurrent MCP tool calls during cache expiry cause duplicate K8s API calls and potential inconsistent cache state (TOCTOU race).

## Fix

Added `_namespace_cache_lock = asyncio.Lock()` with double-checked locking:
- Fast path: read cache without lock (no contention for cache hits)
- Slow path: acquire lock, re-check cache, then fetch from K8s API

## Testing

Verified with MCP Inspector: `list_namespaces` returns correct namespace list.

Closes #44