### PR TITLE
fix: replace blocking time.sleep with asyncio.sleep in async context (closes #125)

### DIFF
--- a/src/helpers/kubearchive_integration.py
+++ b/src/helpers/kubearchive_integration.py
@@ -8,6 +8,7 @@ KubeArchive stores Kubernetes resources off-cluster and provides a REST API
 for accessing historical resource states and logs.
 """
 
+import asyncio
 import os
 import logging
 import aiohttp
@@ -16,7 +17,6 @@ import base64
 import tempfile
 import subprocess
 import socket
-import time
 import yaml
 from typing import Dict, List, Optional, Any, Tuple, Union
 from datetime import datetime
@@ -533,8 +533,10 @@ class KubeArchiveEndpointDiscovery:
                 stderr=subprocess.PIPE
             )
 
-            # Wait a bit for port-forward to establish
-            time.sleep(2)
+            # Wait for port-forward to establish.
+            # Using asyncio.sleep (not time.sleep) to avoid blocking the event loop,
+            # which would freeze all concurrent MCP tool requests for the duration.
+            await asyncio.sleep(2)
 
             # Check if process is still running
             if self._port_forward_process.poll() is not None:
@@ -556,7 +558,7 @@ class KubeArchiveEndpointDiscovery:
             logger.error(f"Error setting up port-forward: {e}")
             return None
 
-    def stop_port_forward(self):
+    def stop_port_forward(self) -> None:
         """Stop the port-forward process if running."""
         if self._port_forward_process:
             try:
@@ -578,7 +580,7 @@ class KubeArchiveEndpointDiscovery:
         """Cleanup: stop port-forward process."""
         self.stop_port_forward()
 
-    def clear_cache(self):
+    def clear_cache(self) -> None:
         """Clear cached endpoint (useful when endpoint becomes unavailable)."""
         self._cached_endpoint = None
     def get_cached_endpoint(self) -> Optional[str]:


### PR DESCRIPTION
## Root Cause

`time.sleep(2)` in `_setup_port_forward` (line 520) is a synchronous C-level blocking call inside an `async def` function. It freezes the entire asyncio event loop for 2 seconds, stalling all concurrent MCP tool requests during local development port-forwarding.

## Fix

**Approach 2 (Defensive)** — selected from 3 simulated approaches:

1. Replaced `time.sleep(2)` with `await asyncio.sleep(2)` — yields control to the event loop during the wait
2. Added `import asyncio` (was not previously imported)
3. Removed `import time` (verified: only usage in file was this sleep call)
4. Added explanatory comment documenting the async constraint

## Why This Approach

- **Approach 1 (Minimal)** rejected: leaves dead `import time` and no documentation
- **Approach 3 (Refactor)** rejected: converting `subprocess.Popen` to `asyncio.create_subprocess_exec` breaks `stop_port_forward` (sync method calling `.wait(timeout=5)`) and the type annotation at line 93

## Investigation Trace

1. Confirmed `import time` at line 19, `asyncio` NOT imported
2. Found `time.sleep(2)` at line 520 inside `async def _setup_port_forward`
3. Searched all `time.` usages — only one (line 520). Lines 1652/1660/1667 use `datetime`, not `time`
4. Verified removing `import time` is safe
5. Verified `subprocess` import must stay (15 usages across the file)

Closes #125