### PR TITLE
docs: add README sections for ML persistence, KubeArchive, and Prometheus/Thanos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ An open source MCP (Model Context Protocol) server empowering SREs with intellig
 - [Installation](#installation)
 - [Usage Examples](#usage-examples)
 - [Configuration](#configuration)
+- [ML Model Persistence](#ml-model-persistence)
+- [KubeArchive Integration](#kubearchive-integration)
+- [Prometheus/Thanos Integration](#prometheusthanos-integration)
 - [Available Tools](#available-tools)
 - [Architecture](#architecture)
 - [How It Works](#how-it-works)
@@ -32,7 +35,7 @@ An open source MCP (Model Context Protocol) server empowering SREs with intellig
 
 ## Overview
 
-LUMINO MCP Server transforms how Site Reliability Engineers (SREs) and DevOps teams interact with Kubernetes clusters. By exposing 37 specialized tools through the Model Context Protocol, it enables AI assistants to:
+LUMINO MCP Server transforms how Site Reliability Engineers (SREs) and DevOps teams interact with Kubernetes clusters. By exposing 39 specialized tools through the Model Context Protocol, it enables AI assistants to:
 
 - **Monitor** cluster health, resources, and pipeline status in real-time
 - **Analyze** logs, events, and anomalies using statistical and ML techniques
@@ -43,6 +46,7 @@ LUMINO MCP Server transforms how Site Reliability Engineers (SREs) and DevOps te
 ## Features
 
 ### Kubernetes & OpenShift Operations
+
 - Namespace and pod management
 - Resource querying with flexible output formats
 - Label-based resource search across clusters
@@ -50,6 +54,7 @@ LUMINO MCP Server transforms how Site Reliability Engineers (SREs) and DevOps te
 - etcd log analysis
 
 ### Tekton Pipeline Intelligence
+
 - Pipeline and task run monitoring across namespaces
 - Detailed log retrieval with optional cleaning
 - Failed pipeline root cause analysis
@@ -57,6 +62,7 @@ LUMINO MCP Server transforms how Site Reliability Engineers (SREs) and DevOps te
 - CI/CD performance baselining
 
 ### Advanced Log Analysis
+
 - Smart log summarization with configurable detail levels
 - Streaming analysis for large log volumes
 - Hybrid analysis combining multiple strategies
@@ -64,6 +70,7 @@ LUMINO MCP Server transforms how Site Reliability Engineers (SREs) and DevOps te
 - Anomaly detection with severity classification
 
 ### Predictive & Proactive Monitoring
+
 - Statistical anomaly detection using z-score analysis
 - Predictive log analysis for early warning
 - Resource bottleneck forecasting
@@ -71,12 +78,14 @@ LUMINO MCP Server transforms how Site Reliability Engineers (SREs) and DevOps te
 - TLS certificate issue investigation
 
 ### Event Intelligence
+
 - Smart event retrieval with multiple strategies
 - Progressive event analysis (overview to deep-dive)
 - Advanced analytics with ML pattern detection
 - Log-event correlation
 
 ### Simulation & What-If Analysis
+
 - Monte Carlo simulation for configuration changes
 - Impact analysis before deployment
 - Risk assessment with configurable tolerance
@@ -90,7 +99,7 @@ Get started with LUMINO in under 2 minutes:
 
 Simply ask Claude Code to provision the Lumino MCP server for you by pasting this prompt:
 
-```
+```text
 Provision the Lumino MCP server as a project-local MCP integration:
 
 1. Clone the repository:
@@ -126,6 +135,7 @@ Provision the Lumino MCP server as a project-local MCP integration:
 ### For Other MCP Clients
 
 Choose your preferred installation method:
+
 - **MCPM (Recommended)**: `mcpm install @spre-sre/lumino-mcp-server`
 - **Manual Setup**: See detailed [MCP Client Integration](#mcp-client-integration) instructions
 
@@ -133,13 +143,14 @@ Choose your preferred installation method:
 
 Once installed, test with a simple query:
 
-```
+```text
 "List all namespaces in my Kubernetes cluster"
 ```
 
 ## Prerequisites
 
 ### Required
+
 - **Python 3.10 or higher** - Core runtime
 - **MCP Client** - One of:
   - [Claude Desktop](https://claude.ai/download)
@@ -148,10 +159,12 @@ Once installed, test with a simple query:
   - [Cursor IDE](https://cursor.sh/)
 
 ### For Kubernetes Features
+
 - **Kubernetes/OpenShift Access** - Valid kubeconfig with read permissions
 - **RBAC Permissions** - Ability to list pods, namespaces, and other resources
 
 ### Optional (Recommended)
+
 - **[uv](https://docs.astral.sh/uv/)** - Faster dependency management than pip
 - **[MCPM](https://github.com/spre-sre/mcpm)** - Easiest installation experience
 - **Prometheus** - For advanced metrics and forecasting features
@@ -217,15 +230,15 @@ The server automatically detects the environment and switches transport modes.
 
 Investigate and diagnose complex failures with automated analysis:
 
-```
+```text
 "Generate a comprehensive RCA report for the failed pipeline run 'build-api-pr-456' in namespace ci-cd"
 ```
 
-```
+```text
 "Analyze what caused pod crashes in namespace production over the last 6 hours and correlate with resource events"
 ```
 
-```
+```text
 "Investigate the TLS certificate issues affecting services in namespace ingress-nginx"
 ```
 
@@ -233,19 +246,19 @@ Investigate and diagnose complex failures with automated analysis:
 
 Anticipate problems before they impact your systems:
 
-```
+```text
 "Predict resource bottlenecks across all production namespaces for the next 48 hours"
 ```
 
-```
+```text
 "Analyze historical pipeline performance and detect anomalies in build times for the last 30 days"
 ```
 
-```
+```text
 "Check cluster certificate health and alert me about any certificates expiring in the next 60 days"
 ```
 
-```
+```text
 "Use predictive log analysis to identify potential failures in namespace monitoring before they occur"
 ```
 
@@ -253,15 +266,15 @@ Anticipate problems before they impact your systems:
 
 Test changes safely before applying them to production:
 
-```
+```text
 "Simulate the impact of increasing memory limits to 4Gi for all pods in namespace backend-services"
 ```
 
-```
+```text
 "Run a what-if scenario for scaling deployments to 10 replicas and analyze resource consumption"
 ```
 
-```
+```text
 "Simulate configuration changes for nginx ingress controller and assess risk to existing traffic"
 ```
 
@@ -269,15 +282,15 @@ Test changes safely before applying them to production:
 
 Understand system architecture and component relationships:
 
-```
+```text
 "Generate a live topology map of all services, deployments, and their dependencies in namespace microservices"
 ```
 
-```
+```text
 "Map the complete dependency graph for the payment-service including all connected resources"
 ```
 
-```
+```text
 "Show me the topology of components affected by the cert-manager service"
 ```
 
@@ -285,19 +298,19 @@ Understand system architecture and component relationships:
 
 Deep-dive into complex issues with multi-faceted analysis:
 
-```
+```text
 "Perform an adaptive namespace investigation for production - analyze logs, events, and resource patterns"
 ```
 
-```
+```text
 "Create a detailed investigation report for resource constraints and bottlenecks in namespace data-processing"
 ```
 
-```
+```text
 "Trace pipeline execution for commit SHA abc123def from source to deployment across all namespaces"
 ```
 
-```
+```text
 "Search logs semantically for 'authentication failures related to expired tokens' across the last 24 hours"
 ```
 
@@ -305,19 +318,19 @@ Deep-dive into complex issues with multi-faceted analysis:
 
 Optimize and troubleshoot your continuous delivery pipelines:
 
-```
+```text
 "Establish performance baselines for all Tekton pipelines and flag runs deviating by more than 2 standard deviations"
 ```
 
-```
+```text
 "Trace the complete pipeline flow for image 'api:v2.5.3' from build to production deployment"
 ```
 
-```
+```text
 "Analyze failed pipeline runs in namespace tekton-pipelines and identify common failure patterns"
 ```
 
-```
+```text
 "Compare current pipeline run times against 30-day baseline and highlight performance degradation"
 ```
 
@@ -325,15 +338,15 @@ Optimize and troubleshoot your continuous delivery pipelines:
 
 Multi-level event investigation from overview to deep-dive:
 
-```
+```text
 "Start with an overview of events in namespace kube-system, then drill down into critical issues"
 ```
 
-```
+```text
 "Perform advanced event analytics with ML pattern detection for namespace monitoring over the last 12 hours"
 ```
 
-```
+```text
 "Correlate events with pod logs to identify the root cause of CrashLoopBackOff in namespace applications"
 ```
 
@@ -341,19 +354,19 @@ Multi-level event investigation from overview to deep-dive:
 
 Stay informed about cluster health and pipeline status:
 
-```
+```text
 "Show me the status of all Tekton pipeline runs cluster-wide and highlight long-running pipelines"
 ```
 
-```
+```text
 "List all failed TaskRuns in the last hour with error details and recommended actions"
 ```
 
-```
+```text
 "Monitor OpenShift cluster operators and alert on any degraded components"
 ```
 
-```
+```text
 "Check MachineConfigPool status and show which nodes are being updated"
 ```
 
@@ -361,15 +374,15 @@ Stay informed about cluster health and pipeline status:
 
 Ensure cluster security and certificate management:
 
-```
+```text
 "Scan all namespaces for expiring certificates and generate a renewal schedule"
 ```
 
-```
+```text
 "Investigate TLS certificate issues causing handshake failures in namespace istio-system"
 ```
 
-```
+```text
 "Audit all secrets and configmaps for sensitive data exposure patterns"
 ```
 
@@ -377,15 +390,15 @@ Ensure cluster security and certificate management:
 
 Leverage machine learning for pattern detection:
 
-```
+```text
 "Use streaming log analysis to process large log volumes from namespace data-pipeline with error pattern detection"
 ```
 
-```
+```text
 "Detect anomalies in log patterns using ML analysis with medium severity threshold for namespace api-gateway"
 ```
 
-```
+```text
 "Analyze resource utilization trends using Prometheus metrics and forecast capacity needs"
 ```
 
@@ -409,6 +422,158 @@ The server automatically detects Kubernetes configuration:
 | `LOG_LEVEL` | Logging verbosity (DEBUG, INFO, WARNING, ERROR) | `INFO` | Debugging issues or reducing log noise |
 | `MCP_SERVER_LOG_LEVEL` | MCP framework log level | `INFO` | Troubleshooting MCP protocol issues |
 | `PYTHONUNBUFFERED` | Disable Python output buffering | - | Recommended for MCP clients to see real-time logs |
+| `KUBEARCHIVE_HOST` | Explicit KubeArchive API endpoint URL | Auto-detected | Custom KubeArchive endpoint or non-standard deployment |
+| `KUBEARCHIVE_ENABLED` | Enable/disable KubeArchive integration | `true` | Set to `false` to disable KubeArchive queries entirely |
+| `THANOS_URL` | Thanos Query endpoint URL (highest priority for metrics) | Auto-detected | Custom Thanos Query endpoint; takes precedence over `PROMETHEUS_URL` |
+| `PROMETHEUS_TOKEN` | Bearer token for Prometheus/Thanos authentication | Auto-detected | Explicit auth token when auto-detection fails |
+| `OPENSHIFT_TOKEN` | OpenShift bearer token for Prometheus/Thanos | Auto-detected | Alternative to `PROMETHEUS_TOKEN` for OpenShift clusters |
+| `OC_TOKEN` | OpenShift CLI token fallback | Auto-detected | Last-resort token fallback for Prometheus/Thanos auth |
+
+## ML Model Persistence
+
+The `predictive_log_analyzer` tool persists trained ML models and training data locally in `~/.lumino/`. This enables model reuse across server restarts and incremental learning from historical failure patterns.
+
+### Directory Structure
+
+```text
+~/.lumino/
+├── models/                     # Trained ML models
+│   ├── {model_id}.joblib       # Serialized model (e.g. IsolationForest via joblib)
+│   ├── {model_id}.meta.json    # Model metadata (created, last used, performance metrics)
+│   └── model_index.json        # Index tracking all models and the current active model
+└── training_data/              # Training data store
+    └── training_data.db        # SQLite database
+```
+
+Model IDs follow the pattern `predictive_log_v1_YYYYMMDD_HHMMSS`.
+
+### Training Data Database
+
+The SQLite database (`training_data.db`) contains four tables:
+
+| Table | Purpose |
+|-------|---------|
+| `log_samples` | Preprocessed log samples with extracted features, namespace, pod name, error indicators, and message entropy |
+| `failure_labels` | Failure events collected from Kubernetes events, failed PipelineRuns, and unhealthy pod statuses. Failure types include: `oom`, `crash`, `image`, `scheduling`, `storage`, `config`, `health`, `network`, `timeout`, `pipeline_failure`, `permission`, `resource_limits` |
+| `log_failure_correlations` | Time-proximity correlations between log samples and failure events (scored 0.5--1.0 based on temporal distance within a 30-minute window) |
+| `training_runs` | Training run history recording model_id, samples used, labels used, performance metrics, and completion status |
+
+All four tables include a `cluster_id` column for multi-cluster support. The cluster ID is derived from the active kubeconfig context name (e.g. `api-stone-prod-p02-hjvn-p1-openshiftapps-com:6443`) or falls back to `in-cluster-{KUBERNETES_SERVICE_HOST}` when running inside a pod.
+
+### Clearing Stale Data
+
+**Programmatic cleanup** via the `manage_prediction_training_data` tool (action `cleanup`):
+
+- `cleanup_old_models(max_age_days=30, keep_min=3)` -- removes models older than 30 days, always keeping the 3 most recent
+- `cleanup_old_data(max_age_days=90)` -- removes log samples, failure labels, and correlations older than 90 days
+
+**Manual cleanup**:
+
+```bash
+rm -rf ~/.lumino/              # Clear everything (models + training data)
+rm -rf ~/.lumino/models/       # Clear just models
+rm -rf ~/.lumino/training_data/ # Clear just training data (SQLite DB)
+```
+
+**Disk usage note**: Models accumulate over time. The default cleanup keeps models up to 30 days old with a minimum of 3 retained. Training data is kept for 90 days. Run the `manage_prediction_training_data` tool with action `cleanup` periodically to reclaim disk space.
+
+## KubeArchive Integration
+
+KubeArchive stores Kubernetes resources off-cluster and provides a REST API for historical resource states and logs. LUMINO uses KubeArchive as a fallback when pods, PipelineRuns, or TaskRuns have been garbage-collected from the live cluster. The `query_kubearchive` tool queries this archive transparently.
+
+### Endpoint Auto-Discovery
+
+The endpoint is discovered automatically using a 5-step chain (first match wins):
+
+1. **`KUBEARCHIVE_HOST` environment variable** (highest priority)
+2. **OpenShift Route** named `kubearchive-api-server` in namespaces: `kubearchive`, `product-kubearchive`, `default`
+3. **Kubernetes Ingress** named `kubearchive-api-server` in the same namespaces
+4. **Kubernetes Service** named `kubearchive-api-server` (in-cluster DNS: `https://kubearchive-api-server.<namespace>.svc.cluster.local:<port>`)
+5. **Kubeconfig-based Route inference** -- constructs candidate URLs from the API server domain (pattern: `https://kubearchive-api-server-{namespace}.apps.{cluster-domain}`) and probes `/livez`
+
+Results are cached at startup. On connection failure, the cache is cleared and re-probed on the next request.
+
+### Local Development (Port-Forwarding)
+
+When running outside the cluster, if an in-cluster Service endpoint is discovered (step 4), LUMINO automatically sets up `kubectl port-forward`:
+
+```bash
+kubectl port-forward -n {namespace} svc/kubearchive-api-server {local_port}:{remote_port}
+```
+
+- Tries ports 8081--8090, then falls back to a system-assigned port
+- The port-forward process is auto-started and auto-cleaned up on server exit
+- If `kubectl` is not available, LUMINO logs a manual fallback command for the user
+
+### Authentication
+
+KubeArchive authentication uses the following priority chain:
+
+1. Provided token (from constructor / previous session)
+2. In-cluster service account token (`/var/run/secrets/kubernetes.io/serviceaccount/token`)
+3. Existing Kubernetes client token (extracted from the API client initialized at server startup)
+4. OpenShift `oc whoami -t` token (for OpenShift clusters)
+5. Auto-created short-lived service account token (`kubectl create token`, 1-hour duration, Kubernetes only)
+
+### KubeArchive Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KUBEARCHIVE_HOST` | Explicit KubeArchive API endpoint URL | Auto-detected |
+| `KUBEARCHIVE_ENABLED` | Set to `false` to disable KubeArchive integration | `true` |
+
+## Prometheus/Thanos Integration
+
+LUMINO auto-discovers Prometheus or Thanos Query endpoints for the `prometheus_query`, `resource_bottleneck_forecaster`, and `ci_cd_performance_baselining_tool` tools. Thanos Query implements the Prometheus HTTP API and is preferred when available since it provides a unified, deduplicated view across replicas.
+
+### Endpoint Discovery Priority
+
+| Priority | Source | Endpoint Type |
+|----------|--------|---------------|
+| 0 | `THANOS_URL` env var | thanos |
+| 1 | `PROMETHEUS_URL` env var | prometheus |
+| 2 | Predefined cluster endpoints (in code) | varies |
+| 3 | 5-minute TTL cache | cached |
+| 4 | Auto-discovery chain (see below) | detected |
+| 5 | Predefined fallback endpoints | varies |
+
+Auto-discovery order depends on runtime environment:
+
+- **In-cluster**: Thanos services --> Prometheus services --> Prometheus Operator CRD --> OpenShift Routes
+- **Local/outside cluster**: OpenShift Routes --> Thanos services --> Prometheus Operator CRD --> Prometheus services
+
+### Auto-Discovery Details
+
+**OpenShift Routes**: Searches the `openshift-monitoring` namespace. Prefers the `thanos-querier` route over `prometheus-k8s`. Falls back to any route with `prometheus` in the name. Detects protocol from TLS termination config.
+
+**Thanos Services**: Searches namespaces `openshift-monitoring`, `monitoring`, `thanos`, `observability`, `kube-prometheus`. Priority service names: `thanos-query-frontend`, `thanos-querier`, `thanos-query`. Also searches via label selectors: `app.kubernetes.io/name=thanos-query`, `app.kubernetes.io/component=query,app.kubernetes.io/name=thanos`, `app=thanos-query`, `app=thanos-querier`.
+
+**Prometheus Services**: Searches namespaces `openshift-monitoring`, `monitoring`, `prometheus`, `kube-prometheus`, `observability`. Priority service names: `prometheus-server`, `prometheus-k8s`, `prometheus`. Also searches via label selectors: `app=prometheus`, `app.kubernetes.io/name=prometheus`, `app.kubernetes.io/component=prometheus`.
+
+**Prometheus Operator CRD**: Discovers via `monitoring.coreos.com/v1` Prometheus custom resources and their associated services (pattern: `prometheus-{name}` in the same namespace).
+
+### Prometheus/Thanos Authentication
+
+Authentication for Prometheus/Thanos uses the following 5 methods in priority order:
+
+1. `oc whoami -t` -- fresh OpenShift token (most reliable for OpenShift)
+2. Re-read kubeconfig file for current token
+3. In-memory Kubernetes client config token
+4. ServiceAccount token file (`/var/run/secrets/kubernetes.io/serviceaccount/token`)
+5. Environment variables: `PROMETHEUS_TOKEN`, `OPENSHIFT_TOKEN`, `OC_TOKEN` (checked in that order)
+
+### Configuration Example
+
+```json
+{
+  "env": {
+    "THANOS_URL": "https://thanos-querier.example.com",
+    "PROMETHEUS_TOKEN": "your-bearer-token"
+  }
+}
+```
+
+**Note**: The endpoint cache has a 5-minute TTL. If you change `THANOS_URL` or `PROMETHEUS_URL` at runtime, the new value takes effect on the next query.
 
 ## Available Tools
 
@@ -498,12 +663,13 @@ The server automatically detects Kubernetes configuration:
 | `ci_cd_performance_baselining_tool` | Pipeline performance baselines |
 | `pipeline_tracer` | Trace pipelines by commit, PR, or image |
 
-### Topology & Prediction (2 tools)
+### Topology & Prediction (3 tools)
 
 | Tool | Description |
 |------|-------------|
 | `live_system_topology_mapper` | Real-time system topology mapping |
 | `predictive_log_analyzer` | Predict issues from log patterns |
+| `manage_prediction_training_data` | Manage training data for predictive log analyzer |
 
 ### Simulation (1 tool)
 
@@ -513,19 +679,21 @@ The server automatically detects Kubernetes configuration:
 
 ## Architecture
 
-```
+```text
 lumino-mcp-server/
 ├── main.py                 # Entry point with transport detection
 ├── src/
-│   ├── server-mcp.py       # MCP server with all 37 tools
+│   ├── server-mcp.py       # MCP server with all 39 tools
 │   └── helpers/
-│       ├── constants.py    # Shared constants
-│       ├── event_analysis.py    # Event processing logic
-│       ├── failure_analysis.py  # RCA algorithms
-│       ├── log_analysis.py      # Log processing
-│       ├── resource_topology.py # Topology mapping
-│       ├── semantic_search.py   # NLP search
-│       └── utils.py             # Utility functions
+│       ├── constants.py              # Shared constants
+│       ├── event_analysis.py         # Event processing logic
+│       ├── failure_analysis.py       # RCA algorithms
+│       ├── kubearchive_integration.py # KubeArchive API client & discovery
+│       ├── log_analysis.py           # Log processing
+│       ├── ml_persistence.py         # ML model & training data storage
+│       ├── resource_topology.py      # Topology mapping
+│       ├── semantic_search.py        # NLP search
+│       └── utils.py                  # Utility functions
 └── pyproject.toml          # Project configuration
 ```
 
@@ -533,7 +701,7 @@ lumino-mcp-server/
 
 LUMINO acts as a bridge between AI assistants and your Kubernetes infrastructure through the Model Context Protocol:
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                        AI Assistant Layer                        │
 │          (Claude Desktop, Claude Code CLI, Gemini CLI)          │
@@ -591,7 +759,7 @@ LUMINO acts as a bridge between AI assistants and your Kubernetes infrastructure
 
 ### Key Features
 
-- **Stateless Design** - No data persistence, queries cluster in real-time
+- **Minimal Local State** - Queries cluster in real-time; optional ML model persistence in `~/.lumino/` for predictive analytics (see [ML Model Persistence](#ml-model-persistence))
 - **Automatic Transport Detection** - Switches between stdio (local) and HTTP (K8s) modes
 - **Token Budget Management** - Adaptive strategies to handle large log volumes
 - **Intelligent Caching** - Smart caching for frequently accessed data
@@ -638,11 +806,13 @@ mcpm install @spre-sre/lumino-mcp-server --global
 ```
 
 **Short syntax explained**:
+
 - `@owner/repo` - Installs from GitHub (default: `https://github.com/owner/repo.git`)
 - `gl:@owner/repo` - Installs from GitLab (`https://gitlab.com/owner/repo.git`)
 - Full URL - Works with any Git repository
 
 This will:
+
 - Clone the repository to `~/.mcp/servers/lumino-mcp-server/`
 - Auto-detect Python project and install dependencies using `uv` (or pip)
 - Register with Claude Code CLI or Gemini CLI configuration automatically
@@ -936,7 +1106,7 @@ After configuring any client, test the connection:
 
 2. **Test a simple query**:
 
-```
+```text
 "List all namespaces in my Kubernetes cluster"
 ```
 
@@ -949,9 +1119,9 @@ uv run python main.py
 ```
 
 Expected output:
-```
+```text
 MCP Server running in stdio mode
-Available tools: 37
+Available tools: 39
 Waiting for requests...
 ```
 
@@ -1029,25 +1199,25 @@ LUMINO automatically manages AI context limits:
 ### Query Optimization Tips
 
 **Use Namespace Filtering**
-```
+```text
 ✅ "Analyze logs for pods in namespace production"
 ❌ "Analyze all pod logs in the cluster"
 ```
 
 **Specify Time Windows**
-```
+```text
 ✅ "Show events from the last 2 hours"
 ❌ "Show all events" (might return thousands)
 ```
 
 **Leverage Smart Tools**
-```
+```text
 ✅ "smart_summarize_pod_logs" - Adaptive analysis
 ❌ Direct log dumps - No processing
 ```
 
 **Use Progressive Analysis**
-```
+```text
 ✅ Start with "overview" → drill down to "detailed"
 ❌ Jump directly to "deep_dive" on large datasets
 ```
@@ -1069,7 +1239,7 @@ LUMINO uses intelligent caching for frequently accessed data:
 
 - **15-minute cache** - For web-fetched content
 - **Session cache** - For hybrid log analysis
-- **No persistence** - All data queries cluster in real-time
+- **ML model persistence** - Predictive models and training data stored locally in `~/.lumino/` (see [ML Model Persistence](#ml-model-persistence))
 
 ### Concurrent Requests
 
@@ -1089,20 +1259,20 @@ The server handles multiple concurrent requests efficiently:
 | Kubernetes | 200m-1 | 512Mi-1Gi | Minimal |
 | High-load | 1-2 | 1-2Gi | Minimal |
 
-**Note**: LUMINO is stateless and requires minimal resources. Most processing happens in the AI assistant.
+**Note**: LUMINO requires minimal resources. ML models and training data are persisted locally in `~/.lumino/` (see [ML Model Persistence](#ml-model-persistence)). Most processing happens in the AI assistant.
 
 ## Troubleshooting
 
 ### Common Issues
 
 **No Kubernetes cluster found**
-```
+```text
 Error: Unable to load kubeconfig
 ```
 Ensure you have a valid kubeconfig at `~/.kube/config` or are running inside a cluster.
 
 **Permission denied for resources**
-```
+```text
 Error: Forbidden - User cannot list resource
 ```
 Check your RBAC permissions. The server needs read access to the resources you want to query.

--- a/README.md
+++ b/README.md
@@ -454,11 +454,11 @@ The SQLite database (`training_data.db`) contains four tables:
 | Table | Purpose |
 |-------|---------|
 | `log_samples` | Preprocessed log samples with extracted features, namespace, pod name, error indicators, and message entropy |
-| `failure_labels` | Failure events collected from Kubernetes events, failed PipelineRuns, and unhealthy pod statuses. Failure types include: `oom`, `crash`, `image`, `scheduling`, `storage`, `config`, `health`, `network`, `timeout`, `pipeline_failure`, `permission`, `resource_limits` |
+| `failure_labels` | Failure events collected from Kubernetes events, failed PipelineRuns, and unhealthy pod statuses. Failure types include: `oom`, `crash`, `image`, `scheduling`, `storage`, `config`, `health`, `network`, `timeout`, `pipeline_failure`, `permission`, `resource_limits`, `general`, `pod_failure` |
 | `log_failure_correlations` | Time-proximity correlations between log samples and failure events (scored 0.5--1.0 based on temporal distance within a 30-minute window) |
 | `training_runs` | Training run history recording model_id, samples used, labels used, performance metrics, and completion status |
 
-All four tables include a `cluster_id` column for multi-cluster support. The cluster ID is derived from the active kubeconfig context name (e.g. `api-stone-prod-p02-hjvn-p1-openshiftapps-com:6443`) or falls back to `in-cluster-{KUBERNETES_SERVICE_HOST}` when running inside a pod.
+All four tables define a `cluster_id` column for multi-cluster support. Currently, only `log_samples` and `failure_labels` actively populate it during writes; `log_failure_correlations` and `training_runs` leave it NULL. The cluster ID is derived from the active kubeconfig context name (e.g. `api-stone-prod-p02-hjvn-p1-openshiftapps-com:6443`) or falls back to `in-cluster-{KUBERNETES_SERVICE_HOST}` when running inside a pod.
 
 ### Clearing Stale Data
 
@@ -517,10 +517,7 @@ KubeArchive authentication uses the following priority chain:
 
 ### KubeArchive Configuration
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `KUBEARCHIVE_HOST` | Explicit KubeArchive API endpoint URL | Auto-detected |
-| `KUBEARCHIVE_ENABLED` | Set to `false` to disable KubeArchive integration | `true` |
+See the [Configuration](#configuration) section above for `KUBEARCHIVE_HOST` and `KUBEARCHIVE_ENABLED` environment variables.
 
 ## Prometheus/Thanos Integration
 

--- a/docs/help.1
+++ b/docs/help.1
@@ -8,7 +8,7 @@ lumino-mcp-server - MCP Server for Kubernetes, OpenShift, and Tekton monitoring 
 # DESCRIPTION
 The LUMINO MCP Server container provides AI-powered tools for Site Reliability Engineering (SRE) operations on Kubernetes and OpenShift clusters.
 
-The server implements the Model Context Protocol (MCP) to expose 37 specialized tools for monitoring, log analysis, anomaly detection, and troubleshooting.
+The server implements the Model Context Protocol (MCP) to expose 39 specialized tools for monitoring, log analysis, anomaly detection, and troubleshooting.
 
 # USAGE
 Run the container with podman:

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ import os
 import sys
 import logging
 import importlib.util
-import asyncio
 from pathlib import Path
 
 # Add the src directory to the Python path
@@ -21,8 +20,8 @@ sys.path.insert(0, str(src_path))
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 
 logger = logging.getLogger("lumino-mcp-main")
@@ -42,13 +41,13 @@ def main():
         mcp = server_mcp.mcp
 
         # Check if running in Kubernetes (via environment variable)
-        if os.getenv('KUBERNETES_NAMESPACE') or os.getenv('K8S_NAMESPACE'):
+        if os.getenv("KUBERNETES_NAMESPACE") or os.getenv("K8S_NAMESPACE"):
             logger.info("Detected Kubernetes environment - running streamable HTTP server")
             logger.info("Note: Server will bind to 127.0.0.1:8000 (limitation of MCP SDK 1.10.1)")
             logger.info("Using modified health checks to work with localhost binding")
 
             # Use the standard MCP run method with streamable-http transport
-            mcp.run(transport='streamable-http')
+            mcp.run(transport="streamable-http")
 
         else:
             logger.info("Running in local environment - using stdio transport")

--- a/src/helpers/__init__.py
+++ b/src/helpers/__init__.py
@@ -54,7 +54,7 @@ from .constants import (
     LOG_ANALYSIS_CONFIG,
     PIPELINE_ANALYSIS_CONFIG,
     SEMANTIC_SEARCH_CONFIG,
-    KUBEARCHIVE_CONFIG,
+    KUBEARCHIVE_CONFIG,  # noqa: F401 - re-exported
 )
 
 from .semantic_search import (
@@ -112,8 +112,8 @@ from .log_analysis import (
     calculate_entropy,
     extract_log_features,
     train_anomaly_model,
-    train_enhanced_anomaly_model,
-    train_or_load_model,
+    train_enhanced_anomaly_model,  # noqa: F401 - re-exported
+    train_or_load_model,  # noqa: F401 - re-exported
     analyze_log_patterns_for_failure_prediction,
     generate_failure_predictions,
     # Token limit truncation functions
@@ -247,7 +247,7 @@ from .kubearchive_integration import (
     check_kubearchive_availability,
     query_kubearchive_resources,
     format_timestamp_for_kubearchive,
-    setup_kubearchive_client
+    setup_kubearchive_client,
 )
 
 __all__ = [
@@ -436,11 +436,10 @@ __all__ = [
     "ModelVersionManager",
     "build_labels_from_correlations",
     "parse_ml_time_period",
-
     "KubeArchiveEndpointDiscovery",
     "KubeArchiveClient",
     "check_kubearchive_availability",
     "query_kubearchive_resources",
     "format_timestamp_for_kubearchive",
-    "setup_kubearchive_client"
+    "setup_kubearchive_client",
 ]

--- a/src/helpers/constants.py
+++ b/src/helpers/constants.py
@@ -18,73 +18,158 @@ SMART_EVENTS_CONFIG: Dict[str, Any] = {
         "max_events_auto": 50,
         "max_events_raw": 100,
         "token_threshold": 8000,
-        "critical_event_limit": 20
+        "critical_event_limit": 20,
     },
     "severity_keywords": {
         "CRITICAL": [
-            "oom", "killed", "crash", "panic", "fatal", "critical",
-            "emergency", "disaster", "outage", "down", "unavailable"
+            "oom",
+            "killed",
+            "crash",
+            "panic",
+            "fatal",
+            "critical",
+            "emergency",
+            "disaster",
+            "outage",
+            "down",
+            "unavailable",
         ],
         "HIGH": [
-            "error", "failed", "failure", "exception", "timeout",
-            "unreachable", "denied", "refused", "invalid"
+            "error",
+            "failed",
+            "failure",
+            "exception",
+            "timeout",
+            "unreachable",
+            "denied",
+            "refused",
+            "invalid",
         ],
-        "MEDIUM": [
-            "warning", "warn", "retry", "slow", "degraded",
-            "pending", "waiting", "delayed"
-        ],
+        "MEDIUM": ["warning", "warn", "retry", "slow", "degraded", "pending", "waiting", "delayed"],
         "LOW": [
-            "info", "created", "started", "completed", "successful",
-            "ready", "healthy", "normal"
-        ]
+            "info",
+            "created",
+            "started",
+            "completed",
+            "successful",
+            "ready",
+            "healthy",
+            "normal",
+        ],
     },
     "category_keywords": {
         # Order matters: more specific categories should come first
         "FAILURE": [
-            "failed", "failure", "error", "crash", "panic", "exception",
-            "abort", "terminated", "killed", "died", "backoff"
+            "failed",
+            "failure",
+            "error",
+            "crash",
+            "panic",
+            "exception",
+            "abort",
+            "terminated",
+            "killed",
+            "died",
+            "backoff",
         ],
         "IMAGE": [
             # IMAGE before SECURITY to avoid false positives with pod names like "image-rbac-proxy"
-            "imagepull", "pullimage", "errimagepull", "imagepullbackoff",
-            "pull image", "pulling image", "image pull", "registry"
+            "imagepull",
+            "pullimage",
+            "errimagepull",
+            "imagepullbackoff",
+            "pull image",
+            "pulling image",
+            "image pull",
+            "registry",
         ],
         "STORAGE": [
-            "volume", "disk", "storage", "mount", "pvc", "pv",
-            "filesystem", "unmount", "failedmount", "failedattach"
+            "volume",
+            "disk",
+            "storage",
+            "mount",
+            "pvc",
+            "pv",
+            "filesystem",
+            "unmount",
+            "failedmount",
+            "failedattach",
         ],
         "NETWORKING": [
-            "network", "dns", "connection", "unreachable",
-            "endpoint", "route", "ingress", "addedinterface"
+            "network",
+            "dns",
+            "connection",
+            "unreachable",
+            "endpoint",
+            "route",
+            "ingress",
+            "addedinterface",
         ],
         "RESOURCE": [
-            "memory", "cpu", "oom", "oomkilled", "quota exceeded",
-            "resource quota", "limitrange", "evicted"
+            "memory",
+            "cpu",
+            "oom",
+            "oomkilled",
+            "quota exceeded",
+            "resource quota",
+            "limitrange",
+            "evicted",
         ],
         "SCHEDULING": [
-            "scheduled", "unschedulable", "failedscheduling", "preempted",
-            "affinity", "taint", "toleration", "nodeaffinity"
+            "scheduled",
+            "unschedulable",
+            "failedscheduling",
+            "preempted",
+            "affinity",
+            "taint",
+            "toleration",
+            "nodeaffinity",
         ],
         "CONFIGURATION": [
-            "configmap", "secret", "createcontainerconfigerror",
-            "invalidargument", "envvar"
+            "configmap",
+            "secret",
+            "createcontainerconfigerror",
+            "invalidargument",
+            "envvar",
         ],
         "SECURITY": [
-            "forbidden", "unauthorized", "accessdenied", "permission denied",
-            "securitycontext", "podsecurity", "scc violation"
+            "forbidden",
+            "unauthorized",
+            "accessdenied",
+            "permission denied",
+            "securitycontext",
+            "podsecurity",
+            "scc violation",
         ],
         "SCALING": [
-            "scaled", "scaling", "replicas", "horizontalpodautoscaler",
-            "hpa", "scaleup", "scaledown"
+            "scaled",
+            "scaling",
+            "replicas",
+            "horizontalpodautoscaler",
+            "hpa",
+            "scaleup",
+            "scaledown",
         ],
         "LIFECYCLE": [
-            "created", "started", "stopped", "deleted", "killing",
-            "prestop", "poststart", "liveness", "readiness"
+            "created",
+            "started",
+            "stopped",
+            "deleted",
+            "killing",
+            "prestop",
+            "poststart",
+            "liveness",
+            "readiness",
         ],
         "HEALTH": [
-            "healthy", "unhealthy", "probe", "livenessprobe", "readinessprobe",
-            "startupprobe", "health check"
-        ]
+            "healthy",
+            "unhealthy",
+            "probe",
+            "livenessprobe",
+            "readinessprobe",
+            "startupprobe",
+            "health check",
+        ],
     },
     "focus_area_mappings": {
         "errors": ["CRITICAL", "HIGH"],
@@ -93,8 +178,8 @@ SMART_EVENTS_CONFIG: Dict[str, Any] = {
         "performance": ["RESOURCE", "SCHEDULING", "SCALING"],
         "security": ["SECURITY"],
         "infrastructure": ["SCHEDULING", "STORAGE", "NETWORKING"],
-        "health": ["HEALTH", "LIFECYCLE"]
-    }
+        "health": ["HEALTH", "LIFECYCLE"],
+    },
 }
 
 # ============================================================================
@@ -102,19 +187,9 @@ SMART_EVENTS_CONFIG: Dict[str, Any] = {
 # ============================================================================
 
 LOG_ANALYSIS_CONFIG: Dict[str, Any] = {
-    "streaming": {
-        "chunk_size": 500,
-        "max_chunks": 10,
-        "overlap_lines": 50
-    },
-    "summary": {
-        "max_lines": 1000,
-        "pattern_threshold": 3
-    },
-    "hybrid": {
-        "streaming_threshold": 800,
-        "summary_fallback": True
-    }
+    "streaming": {"chunk_size": 500, "max_chunks": 10, "overlap_lines": 50},
+    "summary": {"max_lines": 1000, "pattern_threshold": 3},
+    "hybrid": {"streaming_threshold": 800, "summary_fallback": True},
 }
 
 # ============================================================================
@@ -125,14 +200,14 @@ PIPELINE_ANALYSIS_CONFIG: Dict[str, Any] = {
     "bottleneck_thresholds": {
         "duration_variance": 0.5,
         "failure_rate": 0.1,
-        "resource_utilization": 0.8
+        "resource_utilization": 0.8,
     },
     "failure_patterns": {
         "retry_threshold": 3,
         "timeout_threshold": 3600,  # 1 hour
         "memory_threshold": "1Gi",
-        "cpu_threshold": "1000m"
-    }
+        "cpu_threshold": "1000m",
+    },
 }
 
 # ============================================================================
@@ -142,36 +217,93 @@ PIPELINE_ANALYSIS_CONFIG: Dict[str, Any] = {
 SEMANTIC_SEARCH_CONFIG = {
     "intent_keywords": {
         "troubleshooting": [
-            "error", "issue", "problem", "failure", "bug", "broken",
-            "not working", "failing", "crashed", "down"
+            "error",
+            "issue",
+            "problem",
+            "failure",
+            "bug",
+            "broken",
+            "not working",
+            "failing",
+            "crashed",
+            "down",
         ],
         "monitoring": [
-            "status", "health", "metrics", "performance", "usage",
-            "monitoring", "observability", "alerts"
+            "status",
+            "health",
+            "metrics",
+            "performance",
+            "usage",
+            "monitoring",
+            "observability",
+            "alerts",
         ],
         "deployment": [
-            "deploy", "deployment", "rollout", "release", "install",
-            "update", "upgrade", "version"
+            "deploy",
+            "deployment",
+            "rollout",
+            "release",
+            "install",
+            "update",
+            "upgrade",
+            "version",
         ],
         "configuration": [
-            "config", "configure", "settings", "environment", "variables",
-            "parameters", "properties"
+            "config",
+            "configure",
+            "settings",
+            "environment",
+            "variables",
+            "parameters",
+            "properties",
         ],
         "security": [
-            "security", "permissions", "access", "rbac", "policies",
-            "authentication", "authorization"
-        ]
+            "security",
+            "permissions",
+            "access",
+            "rbac",
+            "policies",
+            "authentication",
+            "authorization",
+        ],
     },
     "k8s_entities": [
-        "pod", "pods", "deployment", "deployments", "service", "services",
-        "configmap", "configmaps", "secret", "secrets", "namespace", "namespaces",
-        "node", "nodes", "pv", "pvc", "ingress", "networkpolicy",
-        "serviceaccount", "role", "rolebinding", "clusterrole", "clusterrolebinding"
+        "pod",
+        "pods",
+        "deployment",
+        "deployments",
+        "service",
+        "services",
+        "configmap",
+        "configmaps",
+        "secret",
+        "secrets",
+        "namespace",
+        "namespaces",
+        "node",
+        "nodes",
+        "pv",
+        "pvc",
+        "ingress",
+        "networkpolicy",
+        "serviceaccount",
+        "role",
+        "rolebinding",
+        "clusterrole",
+        "clusterrolebinding",
     ],
     "tekton_entities": [
-        "pipeline", "pipelines", "pipelinerun", "pipelineruns",
-        "task", "tasks", "taskrun", "taskruns", "trigger", "triggers"
-    ]
+        "pipeline",
+        "pipelines",
+        "pipelinerun",
+        "pipelineruns",
+        "task",
+        "tasks",
+        "taskrun",
+        "taskruns",
+        "trigger",
+        "triggers",
+    ],
 }
 
 # ============================================================================
@@ -181,8 +313,8 @@ SEMANTIC_SEARCH_CONFIG = {
 KUBEARCHIVE_CONFIG = {
     "endpoints": {
         "default": {
-            "url": None,  # Must be set via environment variable: KUBEARCHIVE_URL
-            "description": "Default Kubearchive endpoint"
+            "url": None,  # Must be set via environment variable: KUBEARCHIVE_HOST
+            "description": "Default Kubearchive endpoint",
         }
     },
     "authentication": {
@@ -194,12 +326,12 @@ KUBEARCHIVE_CONFIG = {
         "max_results_per_type": 100,
         "timeout": 30,
         "include_pipelineruns": True,
-        "include_taskruns": True
+        "include_taskruns": True,
     },
     "api_structure": {
         # Expected API paths - may need adjustment based on actual Kubearchive deployment
         "list_resources": "/api/v1/{kind}",
         "get_resource": "/api/v1/namespaces/{namespace}/{kind}/{name}",
-        "get_logs": "/api/v1/namespaces/{namespace}/{kind}/{name}/log"
-    }
+        "get_logs": "/api/v1/namespaces/{namespace}/{kind}/{name}/log",
+    },
 }

--- a/src/helpers/event_analysis.py
+++ b/src/helpers/event_analysis.py
@@ -22,6 +22,7 @@ from .constants import SMART_EVENTS_CONFIG
 
 class EventSeverity(Enum):
     """Event severity levels."""
+
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
     MEDIUM = "MEDIUM"
@@ -30,6 +31,7 @@ class EventSeverity(Enum):
 
 class EventCategory(Enum):
     """Event functional categories."""
+
     FAILURE = "FAILURE"
     SCHEDULING = "SCHEDULING"
     NETWORKING = "NETWORKING"
@@ -55,8 +57,7 @@ class ProgressiveEventAnalyzer:
     def __init__(self, classified_events: List[Dict[str, Any]]):
         self.classified_events = classified_events
         self.timeline_sorted = sorted(
-            classified_events,
-            key=lambda x: x.get("timestamp", datetime.now())
+            classified_events, key=lambda x: x.get("timestamp", datetime.now())
         )
 
     def get_overview(self, max_items: int = 5) -> Dict[str, Any]:
@@ -67,13 +68,13 @@ class ProgressiveEventAnalyzer:
 
         # Get top critical events
         critical_events = [
-            e for e in self.classified_events
-            if e.get("severity") == EventSeverity.CRITICAL.value
+            e for e in self.classified_events if e.get("severity") == EventSeverity.CRITICAL.value
         ][:max_items]
 
         # Get most recent high-impact events
         recent_high_impact = [
-            e for e in self.timeline_sorted[-max_items:]
+            e
+            for e in self.timeline_sorted[-max_items:]
             if e.get("severity") in [EventSeverity.CRITICAL.value, EventSeverity.HIGH.value]
         ]
 
@@ -87,7 +88,7 @@ class ProgressiveEventAnalyzer:
                     "severity": e.get("severity"),
                     "category": e.get("category"),
                     "preview": e.get("event_string", "")[:80] + "...",
-                    "timestamp": e.get("timestamp", datetime.now()).isoformat()
+                    "timestamp": e.get("timestamp", datetime.now()).isoformat(),
                 }
                 for e in critical_events
             ],
@@ -96,7 +97,7 @@ class ProgressiveEventAnalyzer:
                     "severity": e.get("severity"),
                     "category": e.get("category"),
                     "preview": e.get("event_string", "")[:60] + "...",
-                    "timestamp": e.get("timestamp", datetime.now()).isoformat()
+                    "timestamp": e.get("timestamp", datetime.now()).isoformat(),
                 }
                 for e in recent_high_impact
             ],
@@ -104,8 +105,8 @@ class ProgressiveEventAnalyzer:
             "drill_down_suggestions": [
                 "Use 'detailed' level for specific event analysis",
                 "Use 'correlation' level to find event relationships",
-                "Use 'deep_dive' level for comprehensive investigation"
-            ]
+                "Use 'deep_dive' level for comprehensive investigation",
+            ],
         }
 
     def get_detailed_analysis(self, event_filters: Dict[str, Any] = None) -> Dict[str, Any]:
@@ -127,7 +128,7 @@ class ProgressiveEventAnalyzer:
             "severity_analysis": self._analyze_by_severity(filtered_events),
             "temporal_analysis": self._analyze_temporal_patterns(filtered_events),
             "resource_impact": self._analyze_resource_impact(filtered_events),
-            "detailed_recommendations": self._generate_detailed_recommendations(filtered_events)
+            "detailed_recommendations": self._generate_detailed_recommendations(filtered_events),
         }
 
         return analysis
@@ -141,7 +142,7 @@ class ProgressiveEventAnalyzer:
             # Find correlations for specific event
             seed_event = next(
                 (e for e in self.classified_events if str(e.get("timestamp", "")) == seed_event_id),
-                None
+                None,
             )
             if seed_event:
                 correlations = [self._find_event_correlations(seed_event)]
@@ -160,7 +161,7 @@ class ProgressiveEventAnalyzer:
             "event_correlations": correlations,
             "failure_cascades": cascades,
             "root_cause_analysis": root_cause_groups,
-            "correlation_insights": self._generate_correlation_insights(correlations, cascades)
+            "correlation_insights": self._generate_correlation_insights(correlations, cascades),
         }
 
     def _find_all_correlations(self) -> List[Dict[str, Any]]:
@@ -173,10 +174,12 @@ class ProgressiveEventAnalyzer:
             for event in self.classified_events:
                 timestamp = event.get("timestamp", datetime.now())
                 if isinstance(timestamp, str):
-                    timestamp = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+                    timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
 
                 # Round to 5-minute window
-                window_key = timestamp.replace(minute=(timestamp.minute // 5) * 5, second=0, microsecond=0)
+                window_key = timestamp.replace(
+                    minute=(timestamp.minute // 5) * 5, second=0, microsecond=0
+                )
                 if window_key not in time_windows:
                     time_windows[window_key] = []
                 time_windows[window_key].append(event)
@@ -186,18 +189,22 @@ class ProgressiveEventAnalyzer:
                 if len(events) > 1:
                     # Look for related events in the same time window
                     for i, event1 in enumerate(events):
-                        for event2 in events[i+1:]:
-                            correlation_strength = self._calculate_correlation_strength(event1, event2)
+                        for event2 in events[i + 1 :]:
+                            correlation_strength = self._calculate_correlation_strength(
+                                event1, event2
+                            )
                             if correlation_strength > 0.3:  # Threshold for correlation
-                                correlations.append({
-                                    "event1": event1.get("event_string", "")[:100] + "...",
-                                    "event2": event2.get("event_string", "")[:100] + "...",
-                                    "correlation_strength": correlation_strength,
-                                    "time_window": window_time.isoformat(),
-                                    "correlation_type": "temporal_proximity"
-                                })
+                                correlations.append(
+                                    {
+                                        "event1": event1.get("event_string", "")[:100] + "...",
+                                        "event2": event2.get("event_string", "")[:100] + "...",
+                                        "correlation_strength": correlation_strength,
+                                        "time_window": window_time.isoformat(),
+                                        "correlation_type": "temporal_proximity",
+                                    }
+                                )
 
-        except Exception as e:
+        except Exception:
             # Return empty correlations on error
             correlations = []
 
@@ -208,7 +215,7 @@ class ProgressiveEventAnalyzer:
         try:
             seed_timestamp = seed_event.get("timestamp", datetime.now())
             if isinstance(seed_timestamp, str):
-                seed_timestamp = datetime.fromisoformat(seed_timestamp.replace('Z', '+00:00'))
+                seed_timestamp = datetime.fromisoformat(seed_timestamp.replace("Z", "+00:00"))
 
             related_events = []
 
@@ -219,27 +226,33 @@ class ProgressiveEventAnalyzer:
 
                 event_timestamp = event.get("timestamp", datetime.now())
                 if isinstance(event_timestamp, str):
-                    event_timestamp = datetime.fromisoformat(event_timestamp.replace('Z', '+00:00'))
+                    event_timestamp = datetime.fromisoformat(event_timestamp.replace("Z", "+00:00"))
 
                 time_diff = abs((event_timestamp - seed_timestamp).total_seconds())
                 if time_diff <= 600:  # Within 10 minutes
                     correlation_strength = self._calculate_correlation_strength(seed_event, event)
                     if correlation_strength > 0.2:
-                        related_events.append({
-                            "event": event.get("event_string", "")[:100] + "...",
-                            "correlation_strength": correlation_strength,
-                            "time_difference_seconds": time_diff
-                        })
+                        related_events.append(
+                            {
+                                "event": event.get("event_string", "")[:100] + "...",
+                                "correlation_strength": correlation_strength,
+                                "time_difference_seconds": time_diff,
+                            }
+                        )
 
             return {
                 "seed_event": seed_event.get("event_string", "")[:100] + "...",
-                "related_events": sorted(related_events, key=lambda x: x["correlation_strength"], reverse=True)[:5]
+                "related_events": sorted(
+                    related_events, key=lambda x: x["correlation_strength"], reverse=True
+                )[:5],
             }
 
         except Exception as e:
             return {"seed_event": "error", "related_events": [], "error": str(e)}
 
-    def _calculate_correlation_strength(self, event1: Dict[str, Any], event2: Dict[str, Any]) -> float:
+    def _calculate_correlation_strength(
+        self, event1: Dict[str, Any], event2: Dict[str, Any]
+    ) -> float:
         """Calculate correlation strength between two events."""
         try:
             strength = 0.0
@@ -279,27 +292,29 @@ class ProgressiveEventAnalyzer:
                 # Look for events that follow this critical event
                 critical_time = critical_event.get("timestamp", datetime.now())
                 if isinstance(critical_time, str):
-                    critical_time = datetime.fromisoformat(critical_time.replace('Z', '+00:00'))
+                    critical_time = datetime.fromisoformat(critical_time.replace("Z", "+00:00"))
 
                 following_events = []
                 for event in self.timeline_sorted:
                     event_time = event.get("timestamp", datetime.now())
                     if isinstance(event_time, str):
-                        event_time = datetime.fromisoformat(event_time.replace('Z', '+00:00'))
+                        event_time = datetime.fromisoformat(event_time.replace("Z", "+00:00"))
 
                     # Events within 30 minutes after critical event
                     if 0 < (event_time - critical_time).total_seconds() <= 1800:
                         following_events.append(event)
 
                 if len(following_events) >= 3:  # Potential cascade
-                    cascades.append({
-                        "trigger_event": critical_event.get("event_string", "")[:100] + "...",
-                        "cascade_events": len(following_events),
-                        "cascade_duration_minutes": 30,
-                        "cascade_type": "failure_propagation"
-                    })
+                    cascades.append(
+                        {
+                            "trigger_event": critical_event.get("event_string", "")[:100] + "...",
+                            "cascade_events": len(following_events),
+                            "cascade_duration_minutes": 30,
+                            "cascade_type": "failure_propagation",
+                        }
+                    )
 
-        except Exception as e:
+        except Exception:
             cascades = []
 
         return cascades[:5]  # Limit to top 5 cascades
@@ -312,19 +327,39 @@ class ProgressiveEventAnalyzer:
                 "network_issues": [],
                 "authentication_problems": [],
                 "configuration_errors": [],
-                "unknown": []
+                "unknown": [],
             }
 
             for event in self.classified_events:
                 event_content = event.get("event_string", "").lower()
 
-                if any(pattern in event_content for pattern in ["memory limit", "oom", "cpu limit", "disk full", "resource quota", "quota exceeded", "evicted"]):
+                if any(
+                    pattern in event_content
+                    for pattern in [
+                        "memory limit",
+                        "oom",
+                        "cpu limit",
+                        "disk full",
+                        "resource quota",
+                        "quota exceeded",
+                        "evicted",
+                    ]
+                ):
                     root_causes["resource_exhaustion"].append(event)
-                elif any(pattern in event_content for pattern in ["network", "connection", "dns", "timeout"]):
+                elif any(
+                    pattern in event_content
+                    for pattern in ["network", "connection", "dns", "timeout"]
+                ):
                     root_causes["network_issues"].append(event)
-                elif any(pattern in event_content for pattern in ["auth", "permission", "forbidden", "unauthorized"]):
+                elif any(
+                    pattern in event_content
+                    for pattern in ["auth", "permission", "forbidden", "unauthorized"]
+                ):
                     root_causes["authentication_problems"].append(event)
-                elif any(pattern in event_content for pattern in ["config", "invalid", "missing", "not found"]):
+                elif any(
+                    pattern in event_content
+                    for pattern in ["config", "invalid", "missing", "not found"]
+                ):
                     root_causes["configuration_errors"].append(event)
                 else:
                     root_causes["unknown"].append(event)
@@ -333,7 +368,7 @@ class ProgressiveEventAnalyzer:
             return {
                 root_cause: {
                     "count": len(events),
-                    "sample_events": [e.get("event_string", "")[:80] + "..." for e in events[:3]]
+                    "sample_events": [e.get("event_string", "")[:80] + "..." for e in events[:3]],
                 }
                 for root_cause, events in root_causes.items()
                 if len(events) > 0
@@ -342,18 +377,26 @@ class ProgressiveEventAnalyzer:
         except Exception as e:
             return {"error": str(e)}
 
-    def _generate_correlation_insights(self, correlations: List[Dict[str, Any]], cascades: List[Dict[str, Any]]) -> List[str]:
+    def _generate_correlation_insights(
+        self, correlations: List[Dict[str, Any]], cascades: List[Dict[str, Any]]
+    ) -> List[str]:
         """Generate insights from correlation analysis."""
         insights = []
 
         try:
             if correlations:
-                insights.append(f"Found {len(correlations)} event correlations indicating related issues")
+                insights.append(
+                    f"Found {len(correlations)} event correlations indicating related issues"
+                )
 
                 # Analyze correlation strengths
-                strong_correlations = [c for c in correlations if c.get("correlation_strength", 0) > 0.7]
+                strong_correlations = [
+                    c for c in correlations if c.get("correlation_strength", 0) > 0.7
+                ]
                 if strong_correlations:
-                    insights.append(f"{len(strong_correlations)} strong correlations suggest systemic issues")
+                    insights.append(
+                        f"{len(strong_correlations)} strong correlations suggest systemic issues"
+                    )
 
             if cascades:
                 insights.append(f"Detected {len(cascades)} potential failure cascades")
@@ -361,7 +404,9 @@ class ProgressiveEventAnalyzer:
                 insights.append(f"Cascade analysis shows {total_cascade_events} related events")
 
             if not correlations and not cascades:
-                insights.append("No significant event correlations detected - issues appear isolated")
+                insights.append(
+                    "No significant event correlations detected - issues appear isolated"
+                )
 
         except Exception as e:
             insights.append(f"Correlation analysis error: {str(e)}")
@@ -389,54 +434,65 @@ class ProgressiveEventAnalyzer:
 
         # Time-based patterns
         if len(self.timeline_sorted) > 1:
-            time_span = (
-                self.timeline_sorted[-1].get("timestamp", datetime.now()) -
-                self.timeline_sorted[0].get("timestamp", datetime.now())
-            )
+            time_span = self.timeline_sorted[-1].get(
+                "timestamp", datetime.now()
+            ) - self.timeline_sorted[0].get("timestamp", datetime.now())
             patterns["time_span"] = str(time_span)
-            patterns["event_rate"] = f"{len(self.classified_events) / max(time_span.total_seconds() / 3600, 0.1):.1f} events/hour"
+            events_per_hour = len(self.classified_events) / max(
+                time_span.total_seconds() / 3600, 0.1
+            )
+            patterns["event_rate"] = f"{events_per_hour:.1f} events/hour"
 
         # Common keywords
-        all_text = " ".join([
-            event.get("event_string", "")
-            for event in self.classified_events
-        ]).lower()
+        all_text = " ".join(
+            [event.get("event_string", "") for event in self.classified_events]
+        ).lower()
 
         common_terms = ["failed", "error", "oom", "timeout", "unhealthy", "imagepull"]
         patterns["common_issues"] = {
-            term: all_text.count(term)
-            for term in common_terms
-            if all_text.count(term) > 0
+            term: all_text.count(term) for term in common_terms if all_text.count(term) > 0
         }
 
         return patterns
 
-    def _apply_progressive_filters(self, events: List[Dict[str, Any]], filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def _apply_progressive_filters(
+        self, events: List[Dict[str, Any]], filters: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
         """Apply progressive filters to events."""
 
         filtered = events
 
         if "severity" in filters:
-            target_severities = filters["severity"] if isinstance(filters["severity"], list) else [filters["severity"]]
+            target_severities = (
+                filters["severity"]
+                if isinstance(filters["severity"], list)
+                else [filters["severity"]]
+            )
             filtered = [e for e in filtered if e.get("severity") in target_severities]
 
         if "category" in filters:
-            target_categories = filters["category"] if isinstance(filters["category"], list) else [filters["category"]]
+            target_categories = (
+                filters["category"]
+                if isinstance(filters["category"], list)
+                else [filters["category"]]
+            )
             filtered = [e for e in filtered if e.get("category") in target_categories]
 
         if "time_range" in filters:
             # Filter by time range (last N hours)
             hours = filters["time_range"]
             cutoff = datetime.now() - timedelta(hours=hours)
-            filtered = [
-                e for e in filtered
-                if e.get("timestamp", datetime.now()) >= cutoff
-            ]
+            filtered = [e for e in filtered if e.get("timestamp", datetime.now()) >= cutoff]
 
         if "keywords" in filters:
-            keywords = filters["keywords"] if isinstance(filters["keywords"], list) else [filters["keywords"]]
+            keywords = (
+                filters["keywords"]
+                if isinstance(filters["keywords"], list)
+                else [filters["keywords"]]
+            )
             filtered = [
-                e for e in filtered
+                e
+                for e in filtered
                 if any(keyword.lower() in e.get("event_string", "").lower() for keyword in keywords)
             ]
 
@@ -454,7 +510,7 @@ class ProgressiveEventAnalyzer:
                 category_analysis[category] = {
                     "count": 0,
                     "severity_breakdown": {},
-                    "sample_events": []
+                    "sample_events": [],
                 }
 
             category_counts[category] += 1
@@ -467,11 +523,17 @@ class ProgressiveEventAnalyzer:
 
             # Keep sample events (max 3 per category)
             if len(category_analysis[category]["sample_events"]) < 3:
-                category_analysis[category]["sample_events"].append({
-                    "event_string": event.get("event_string", "")[:100] + "..." if len(event.get("event_string", "")) > 100 else event.get("event_string", ""),
-                    "severity": severity,
-                    "timestamp": event.get("timestamp", "").isoformat() if hasattr(event.get("timestamp", ""), 'isoformat') else str(event.get("timestamp", ""))
-                })
+                category_analysis[category]["sample_events"].append(
+                    {
+                        "event_string": event.get("event_string", "")[:100] + "..."
+                        if len(event.get("event_string", "")) > 100
+                        else event.get("event_string", ""),
+                        "severity": severity,
+                        "timestamp": event.get("timestamp", "").isoformat()
+                        if hasattr(event.get("timestamp", ""), "isoformat")
+                        else str(event.get("timestamp", "")),
+                    }
+                )
 
         return category_analysis
 
@@ -486,7 +548,7 @@ class ProgressiveEventAnalyzer:
                     "count": 0,
                     "percentage": 0.0,
                     "categories": {},
-                    "sample_events": []
+                    "sample_events": [],
                 }
 
             severity_analysis[severity]["count"] += 1
@@ -498,16 +560,24 @@ class ProgressiveEventAnalyzer:
 
             # Keep sample events (max 2 per severity)
             if len(severity_analysis[severity]["sample_events"]) < 2:
-                severity_analysis[severity]["sample_events"].append({
-                    "event_string": event.get("event_string", "")[:100] + "..." if len(event.get("event_string", "")) > 100 else event.get("event_string", ""),
-                    "category": category,
-                    "timestamp": event.get("timestamp", "").isoformat() if hasattr(event.get("timestamp", ""), 'isoformat') else str(event.get("timestamp", ""))
-                })
+                severity_analysis[severity]["sample_events"].append(
+                    {
+                        "event_string": event.get("event_string", "")[:100] + "..."
+                        if len(event.get("event_string", "")) > 100
+                        else event.get("event_string", ""),
+                        "category": category,
+                        "timestamp": event.get("timestamp", "").isoformat()
+                        if hasattr(event.get("timestamp", ""), "isoformat")
+                        else str(event.get("timestamp", "")),
+                    }
+                )
 
         # Calculate percentages
         total_events = len(events)
         for severity in severity_analysis:
-            severity_analysis[severity]["percentage"] = (severity_analysis[severity]["count"] / total_events) * 100
+            severity_analysis[severity]["percentage"] = (
+                severity_analysis[severity]["count"] / total_events
+            ) * 100
 
         return severity_analysis
 
@@ -524,14 +594,14 @@ class ProgressiveEventAnalyzer:
             "time_span": "unknown",
             "event_rate": "unknown",
             "peak_periods": [],
-            "patterns": {}
+            "patterns": {},
         }
 
         if len(sorted_events) > 1:
             start_time = sorted_events[0].get("timestamp", datetime.now())
             end_time = sorted_events[-1].get("timestamp", datetime.now())
 
-            if hasattr(start_time, 'total_seconds') or hasattr(end_time, 'total_seconds'):
+            if hasattr(start_time, "total_seconds") or hasattr(end_time, "total_seconds"):
                 try:
                     time_span = end_time - start_time
                     temporal_analysis["time_span"] = str(time_span)
@@ -539,43 +609,49 @@ class ProgressiveEventAnalyzer:
                     if time_span.total_seconds() > 0:
                         rate = len(events) / (time_span.total_seconds() / 3600)
                         temporal_analysis["event_rate"] = f"{rate:.1f} events/hour"
-                except:
+                except (TypeError, ValueError, AttributeError):
                     pass
 
         # Analyze patterns by hour
         hour_counts = {}
         for event in events:
             timestamp = event.get("timestamp", datetime.now())
-            if hasattr(timestamp, 'hour'):
+            if hasattr(timestamp, "hour"):
                 hour = timestamp.hour
                 hour_counts[hour] = hour_counts.get(hour, 0) + 1
 
         if hour_counts:
             max_hour = max(hour_counts, key=hour_counts.get)
-            temporal_analysis["patterns"]["peak_hour"] = f"{max_hour}:00 ({hour_counts[max_hour]} events)"
+            temporal_analysis["patterns"]["peak_hour"] = (
+                f"{max_hour}:00 ({hour_counts[max_hour]} events)"
+            )
 
         return temporal_analysis
 
     def _analyze_resource_impact(self, events: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Analyze resource impact of events."""
-        resource_impact = {
-            "affected_resources": {},
-            "resource_types": {},
-            "severity_impact": {}
-        }
+        resource_impact = {"affected_resources": {}, "resource_types": {}, "severity_impact": {}}
 
         for event in events:
             event_str = event.get("event_string", "").lower()
 
             # Extract resource information from event string
             if "pod" in event_str:
-                resource_impact["resource_types"]["pods"] = resource_impact["resource_types"].get("pods", 0) + 1
+                resource_impact["resource_types"]["pods"] = (
+                    resource_impact["resource_types"].get("pods", 0) + 1
+                )
             if "service" in event_str:
-                resource_impact["resource_types"]["services"] = resource_impact["resource_types"].get("services", 0) + 1
+                resource_impact["resource_types"]["services"] = (
+                    resource_impact["resource_types"].get("services", 0) + 1
+                )
             if "deployment" in event_str:
-                resource_impact["resource_types"]["deployments"] = resource_impact["resource_types"].get("deployments", 0) + 1
+                resource_impact["resource_types"]["deployments"] = (
+                    resource_impact["resource_types"].get("deployments", 0) + 1
+                )
             if "pvc" in event_str or "volume" in event_str:
-                resource_impact["resource_types"]["storage"] = resource_impact["resource_types"].get("storage", 0) + 1
+                resource_impact["resource_types"]["storage"] = (
+                    resource_impact["resource_types"].get("storage", 0) + 1
+                )
 
             severity = event.get("severity", "UNKNOWN")
             if severity not in resource_impact["severity_impact"]:
@@ -585,7 +661,9 @@ class ProgressiveEventAnalyzer:
 
         # Convert sets to lists for JSON serialization
         for severity in resource_impact["severity_impact"]:
-            resource_impact["severity_impact"][severity]["resources"] = list(resource_impact["severity_impact"][severity]["resources"])
+            resource_impact["severity_impact"][severity]["resources"] = list(
+                resource_impact["severity_impact"][severity]["resources"]
+            )
 
         return resource_impact
 
@@ -601,10 +679,18 @@ class ProgressiveEventAnalyzer:
         high_count = len([e for e in events if e.get("severity") == "HIGH"])
 
         if critical_count > 0:
-            recommendations.append(f"URGENT: {critical_count} critical events detected - immediate investigation required")
+            recommendations.append(
+                "URGENT: "
+                f"{critical_count} critical events detected"
+                " - immediate investigation required"
+            )
 
         if high_count > 5:
-            recommendations.append(f"HIGH PRIORITY: {high_count} high-severity events - review and address underlying causes")
+            recommendations.append(
+                "HIGH PRIORITY: "
+                f"{high_count} high-severity events"
+                " - review and address underlying causes"
+            )
 
         # Category-specific recommendations
         categories = {}
@@ -613,19 +699,36 @@ class ProgressiveEventAnalyzer:
             categories[category] = categories.get(category, 0) + 1
 
         if categories.get("FAILURE", 0) > 3:
-            recommendations.append("RELIABILITY: Multiple failure events detected - consider implementing circuit breakers and retry mechanisms")
+            recommendations.append(
+                "RELIABILITY: Multiple failure events detected"
+                " - consider implementing circuit breakers"
+                " and retry mechanisms"
+            )
 
         if categories.get("NETWORKING", 0) > 2:
-            recommendations.append("NETWORKING: Network-related issues detected - verify service mesh configuration and network policies")
+            recommendations.append(
+                "NETWORKING: Network-related issues detected"
+                " - verify service mesh configuration"
+                " and network policies"
+            )
 
         if categories.get("STORAGE", 0) > 1:
-            recommendations.append("STORAGE: Storage issues detected - check PVC status and volume mount configurations")
+            recommendations.append(
+                "STORAGE: Storage issues detected"
+                " - check PVC status and volume mount configurations"
+            )
 
         if categories.get("RESOURCE", 0) > 2:
-            recommendations.append("RESOURCES: Resource constraint issues - review resource requests, limits, and node capacity")
+            recommendations.append(
+                "RESOURCES: Resource constraint issues"
+                " - review resource requests, limits,"
+                " and node capacity"
+            )
 
         if not recommendations:
-            recommendations.append("MONITORING: Events are within normal parameters - continue monitoring")
+            recommendations.append(
+                "MONITORING: Events are within normal parameters - continue monitoring"
+            )
 
         return recommendations
 
@@ -675,7 +778,7 @@ def classify_event_severity_from_string(event_str: str) -> str:
     # Look for the type after the timestamp bracket
     bracket_end = event_content.find("] ")
     if bracket_end >= 0:
-        after_bracket = event_content[bracket_end + 2:].strip()
+        after_bracket = event_content[bracket_end + 2 :].strip()
         if after_bracket.startswith("Normal:") or after_bracket.startswith("normal:"):
             is_normal_event = True
         elif after_bracket.startswith("Warning:") or after_bracket.startswith("warning:"):
@@ -720,15 +823,14 @@ def classify_event_category_from_string(event_str: str) -> str:
     bracket_end = event_content.find("] ")
     is_normal_event = False
     if bracket_end >= 0:
-        after_bracket = event_content[bracket_end + 2:].strip().lower()
+        after_bracket = event_content[bracket_end + 2 :].strip().lower()
         if after_bracket.startswith("normal:"):
             is_normal_event = True
 
     if is_normal_event:
         # For Normal events, check non-failure categories only
         non_failure_categories = {
-            k: v for k, v in SMART_EVENTS_CONFIG["category_keywords"].items()
-            if k != "FAILURE"
+            k: v for k, v in SMART_EVENTS_CONFIG["category_keywords"].items() if k != "FAILURE"
         }
         for category, keywords in non_failure_categories.items():
             if any(keyword in event_lower for keyword in keywords):
@@ -778,20 +880,20 @@ def extract_timestamp_from_string(event_str: str) -> datetime:
     """Extract timestamp from event string."""
 
     # Try to find ISO timestamp (with T separator)
-    iso_pattern = r'(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)'
+    iso_pattern = r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)"
     match = re.search(iso_pattern, event_str)
 
     if match:
         try:
             timestamp_str = match.group(1)
-            if timestamp_str.endswith('Z'):
-                timestamp_str = timestamp_str[:-1] + '+00:00'
-            return datetime.fromisoformat(timestamp_str.replace('Z', '+00:00'))
+            if timestamp_str.endswith("Z"):
+                timestamp_str = timestamp_str[:-1] + "+00:00"
+            return datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
         except ValueError:
             pass
 
     # Try space-separated format: [2026-03-11 04:44:36+00:00] or 2026-03-11 04:44:36+00:00
-    space_pattern = r'(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[+-]\d{2}:\d{2})?)'
+    space_pattern = r"(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[+-]\d{2}:\d{2})?)"
     match = re.search(space_pattern, event_str)
 
     if match:
@@ -823,9 +925,7 @@ def estimate_string_event_tokens(event_str: str) -> int:
 
 
 def smart_sample_string_events(
-    events: List[str],
-    focus_areas: List[str],
-    max_tokens: int
+    events: List[str], focus_areas: List[str], max_tokens: int
 ) -> List[Dict[str, Any]]:
     """Smart sampling for string events."""
 
@@ -838,7 +938,7 @@ def smart_sample_string_events(
             "category": classify_event_category_from_string(event_str),
             "relevance_score": calculate_relevance_score_from_string(event_str, focus_areas),
             "timestamp": extract_timestamp_from_string(event_str),
-            "token_estimate": estimate_string_event_tokens(event_str)
+            "token_estimate": estimate_string_event_tokens(event_str),
         }
         classified_events.append(classified_event)
 
@@ -865,18 +965,14 @@ def smart_sample_string_events(
 
 
 def generate_string_events_summary(
-    classified_events: List[Dict[str, Any]],
-    focus_areas: List[str]
+    classified_events: List[Dict[str, Any]], focus_areas: List[str]
 ) -> Dict[str, Any]:
     """Generate summary from classified string events."""
 
     total_events = len(classified_events)
 
     if total_events == 0:
-        return {
-            "total_events": 0,
-            "message": "No events found in the specified timeframe"
-        }
+        return {"total_events": 0, "message": "No events found in the specified timeframe"}
 
     # Count by severity and category
     severity_counts: Dict[str, int] = {}
@@ -897,12 +993,15 @@ def generate_string_events_summary(
         if focus_area in focus_area_mappings:
             target_items = focus_area_mappings[focus_area]
             relevant_count = sum(
-                1 for event in classified_events
+                1
+                for event in classified_events
                 if event["severity"] in target_items or event["category"] in target_items
             )
             focus_coverage[focus_area] = {
                 "relevant_events": relevant_count,
-                "percentage": round(relevant_count / total_events * 100, 1) if total_events > 0 else 0
+                "percentage": round(relevant_count / total_events * 100, 1)
+                if total_events > 0
+                else 0,
             }
 
     # Time range analysis
@@ -919,12 +1018,9 @@ def generate_string_events_summary(
         "severity_breakdown": severity_counts,
         "category_breakdown": category_counts,
         "focus_area_coverage": focus_coverage,
-        "time_analysis": {
-            "time_span": str(time_span),
-            "event_rate_per_hour": round(event_rate, 2)
-        },
+        "time_analysis": {"time_span": str(time_span), "event_rate_per_hour": round(event_rate, 2)},
         "critical_events": severity_counts.get("CRITICAL", 0),
-        "high_severity_events": severity_counts.get("HIGH", 0)
+        "high_severity_events": severity_counts.get("HIGH", 0),
     }
 
 
@@ -946,14 +1042,18 @@ def generate_string_events_insights(classified_events: List[Dict[str, Any]]) -> 
         insights.append(f"{critical_count} critical events detected requiring immediate attention")
 
     if high_count > total_events * 0.3:
-        insights.append(f"High severity events make up {high_count/total_events:.0%} of total events")
+        insights.append(
+            f"High severity events make up {high_count / total_events:.0%} of total events"
+        )
 
     # Category insights
     category_counts = Counter([e["category"] for e in classified_events])
     dominant_category = category_counts.most_common(1)[0] if category_counts else None
 
     if dominant_category and dominant_category[1] > total_events * 0.4:
-        insights.append(f"{dominant_category[0]} category dominates with {dominant_category[1]} events")
+        insights.append(
+            f"{dominant_category[0]} category dominates with {dominant_category[1]} events"
+        )
 
     # Temporal insights
     timestamps = [e["timestamp"] for e in classified_events]
@@ -963,10 +1063,12 @@ def generate_string_events_insights(classified_events: List[Dict[str, Any]]) -> 
             insights.append("Events clustered in short time window - potential incident burst")
 
     # Pattern insights - use extracted content to avoid false positives from pod names
-    all_text = " ".join([
-        extract_event_content_for_classification(e.get("event_string", ""))
-        for e in classified_events
-    ]).lower()
+    all_text = " ".join(
+        [
+            extract_event_content_for_classification(e.get("event_string", ""))
+            for e in classified_events
+        ]
+    ).lower()
 
     if "oom" in all_text:
         insights.append("Memory-related issues detected - check resource limits")
@@ -999,7 +1101,9 @@ def generate_string_events_recommendations(classified_events: List[Dict[str, Any
     high_count = len([e for e in classified_events if e["severity"] == "HIGH"])
 
     if critical_count >= 5:
-        recommendations.append("IMMEDIATE: Activate incident response - multiple critical events detected")
+        recommendations.append(
+            "IMMEDIATE: Activate incident response - multiple critical events detected"
+        )
     elif critical_count > 0:
         recommendations.append("HIGH PRIORITY: Investigate critical events within 30 minutes")
 
@@ -1030,7 +1134,9 @@ def generate_string_events_recommendations(classified_events: List[Dict[str, Any
             elif category == "SCALING":
                 recommendations.append("Review HPA configuration and scaling thresholds")
             elif category == "HEALTH":
-                recommendations.append("Check probe configurations and application health endpoints")
+                recommendations.append(
+                    "Check probe configurations and application health endpoints"
+                )
 
     # General recommendations
     total_events = len(classified_events)
@@ -1066,7 +1172,7 @@ class MLPatternDetector:
             "resource_usage_patterns": self._detect_resource_patterns(),
             "cyclic_patterns": self._detect_cyclic_patterns(),
             "outlier_events": self._detect_outlier_events(),
-            "predictive_indicators": self._generate_predictive_indicators()
+            "predictive_indicators": self._generate_predictive_indicators(),
         }
 
         return patterns
@@ -1082,7 +1188,7 @@ class MLPatternDetector:
         intervals = []
 
         for i in range(1, len(sorted_events)):
-            prev_time = sorted_events[i-1].get("timestamp", datetime.now())
+            prev_time = sorted_events[i - 1].get("timestamp", datetime.now())
             curr_time = sorted_events[i].get("timestamp", datetime.now())
             interval = (curr_time - prev_time).total_seconds()
             intervals.append(interval)
@@ -1100,14 +1206,18 @@ class MLPatternDetector:
             z_score = abs(interval - mean_interval) / (std_interval + 1e-6)
 
             if z_score > 2.5:  # 2.5 sigma threshold
-                anomalies.append({
-                    "type": "temporal_anomaly",
-                    "interval_seconds": interval,
-                    "z_score": z_score,
-                    "event_index": i + 1,
-                    "severity": "HIGH" if z_score > 3.0 else "MEDIUM",
-                    "description": f"Unusual time gap: {interval:.1f}s (expected ~{mean_interval:.1f}s)"
-                })
+                anomalies.append(
+                    {
+                        "type": "temporal_anomaly",
+                        "interval_seconds": interval,
+                        "z_score": z_score,
+                        "event_index": i + 1,
+                        "severity": "HIGH" if z_score > 3.0 else "MEDIUM",
+                        "description": (
+                            f"Unusual time gap: {interval:.1f}s (expected ~{mean_interval:.1f}s)"
+                        ),
+                    }
+                )
 
         return anomalies[:10]  # Top 10 anomalies
 
@@ -1134,17 +1244,19 @@ class MLPatternDetector:
         # High frequency periods
         for hour, count in hourly_counts.items():
             if count > mean_freq + 2 * std_freq:
-                patterns.append({
-                    "type": "high_frequency_period",
-                    "hour": hour,
-                    "event_count": count,
-                    "deviation": (count - mean_freq) / (std_freq + 1e-6)
-                })
+                patterns.append(
+                    {
+                        "type": "high_frequency_period",
+                        "hour": hour,
+                        "event_count": count,
+                        "deviation": (count - mean_freq) / (std_freq + 1e-6),
+                    }
+                )
 
         return {
             "mean_frequency": mean_freq,
             "std_frequency": std_freq,
-            "patterns": patterns[:15]  # Limit output
+            "patterns": patterns[:15],  # Limit output
         }
 
     def _detect_cyclic_patterns(self) -> Dict[str, Any]:
@@ -1154,11 +1266,7 @@ class MLPatternDetector:
             return {"pattern": "insufficient_data"}
 
         # Extract time features
-        time_features = {
-            "hour_of_day": [],
-            "day_of_week": [],
-            "minute_of_hour": []
-        }
+        time_features = {"hour_of_day": [], "day_of_week": [], "minute_of_hour": []}
 
         for event in self.events:
             timestamp = event.get("timestamp", datetime.now())
@@ -1179,7 +1287,7 @@ class MLPatternDetector:
                     "cyclicity_score": 0.0,
                     "dominant_values": list(value_counts.most_common(3)),
                     "pattern_strength": "LOW",
-                    "note": "Insufficient variance data - all events in same time bucket"
+                    "note": "Insufficient variance data - all events in same time bucket",
                 }
                 continue
 
@@ -1195,7 +1303,11 @@ class MLPatternDetector:
                 cycles[feature_name] = {
                     "cyclicity_score": cyclicity_score,
                     "dominant_values": most_common,
-                    "pattern_strength": "HIGH" if cyclicity_score > 0.7 else "MEDIUM" if cyclicity_score > 0.4 else "LOW"
+                    "pattern_strength": "HIGH"
+                    if cyclicity_score > 0.7
+                    else "MEDIUM"
+                    if cyclicity_score > 0.4
+                    else "LOW",
                 }
 
             except statistics.StatisticsError as e:
@@ -1204,7 +1316,7 @@ class MLPatternDetector:
                     "cyclicity_score": 0.0,
                     "dominant_values": list(value_counts.most_common(3)),
                     "pattern_strength": "LOW",
-                    "error": f"Statistical calculation failed: {str(e)}"
+                    "error": f"Statistical calculation failed: {str(e)}",
                 }
 
         return cycles
@@ -1233,19 +1345,23 @@ class MLPatternDetector:
 
                 # Check for escalation
                 if next_level > current_level:
-                    time_diff = (next_event.get("timestamp", datetime.now()) -
-                               current_event.get("timestamp", datetime.now())).total_seconds()
+                    time_diff = (
+                        next_event.get("timestamp", datetime.now())
+                        - current_event.get("timestamp", datetime.now())
+                    ).total_seconds()
 
-                    escalations.append({
-                        "from_severity": current_severity,
-                        "to_severity": next_severity,
-                        "escalation_time_seconds": time_diff,
-                        "current_event": current_event.get("event_string", "")[:80] + "...",
-                        "escalated_event": next_event.get("event_string", "")[:80] + "...",
-                        "escalation_factor": next_level - current_level
-                    })
+                    escalations.append(
+                        {
+                            "from_severity": current_severity,
+                            "to_severity": next_severity,
+                            "escalation_time_seconds": time_diff,
+                            "current_event": current_event.get("event_string", "")[:80] + "...",
+                            "escalated_event": next_event.get("event_string", "")[:80] + "...",
+                            "escalation_factor": next_level - current_level,
+                        }
+                    )
 
-        except Exception as e:
+        except Exception:
             escalations = []
 
         return escalations[:10]  # Limit to top 10 escalations
@@ -1257,7 +1373,7 @@ class MLPatternDetector:
             "cpu_issues": [],
             "disk_issues": [],
             "network_issues": [],
-            "pod_issues": []
+            "pod_issues": [],
         }
 
         try:
@@ -1265,21 +1381,36 @@ class MLPatternDetector:
                 event_content = event.get("event_string", "").lower()
 
                 if any(pattern in event_content for pattern in ["memory", "oom", "out of memory"]):
-                    resource_patterns["memory_issues"].append(event.get("event_string", "")[:100] + "...")
+                    resource_patterns["memory_issues"].append(
+                        event.get("event_string", "")[:100] + "..."
+                    )
                 elif any(pattern in event_content for pattern in ["cpu", "throttl", "processor"]):
-                    resource_patterns["cpu_issues"].append(event.get("event_string", "")[:100] + "...")
-                elif any(pattern in event_content for pattern in ["disk", "storage", "volume", "pvc"]):
-                    resource_patterns["disk_issues"].append(event.get("event_string", "")[:100] + "...")
-                elif any(pattern in event_content for pattern in ["network", "dns", "connection", "timeout"]):
-                    resource_patterns["network_issues"].append(event.get("event_string", "")[:100] + "...")
+                    resource_patterns["cpu_issues"].append(
+                        event.get("event_string", "")[:100] + "..."
+                    )
+                elif any(
+                    pattern in event_content for pattern in ["disk", "storage", "volume", "pvc"]
+                ):
+                    resource_patterns["disk_issues"].append(
+                        event.get("event_string", "")[:100] + "..."
+                    )
+                elif any(
+                    pattern in event_content
+                    for pattern in ["network", "dns", "connection", "timeout"]
+                ):
+                    resource_patterns["network_issues"].append(
+                        event.get("event_string", "")[:100] + "..."
+                    )
                 elif any(pattern in event_content for pattern in ["pod", "container", "image"]):
-                    resource_patterns["pod_issues"].append(event.get("event_string", "")[:100] + "...")
+                    resource_patterns["pod_issues"].append(
+                        event.get("event_string", "")[:100] + "..."
+                    )
 
             # Return summary with counts
             return {
                 resource_type: {
                     "count": len(issues),
-                    "sample_issues": issues[:3]  # Top 3 samples
+                    "sample_issues": issues[:3],  # Top 3 samples
                 }
                 for resource_type, issues in resource_patterns.items()
                 if len(issues) > 0
@@ -1311,15 +1442,19 @@ class MLPatternDetector:
                 # Events that occur very rarely are potential outliers
                 if frequency < 0.05 and len(events) <= 2:  # Less than 5% frequency
                     for event in events:
-                        outliers.append({
-                            "event": event.get("event_string", "")[:100] + "...",
-                            "rarity_score": 1 - frequency,
-                            "pattern": pattern,
-                            "severity": event.get("severity", "UNKNOWN"),
-                            "timestamp": event.get("timestamp", datetime.now()).isoformat() if isinstance(event.get("timestamp"), datetime) else str(event.get("timestamp", ""))
-                        })
+                        outliers.append(
+                            {
+                                "event": event.get("event_string", "")[:100] + "...",
+                                "rarity_score": 1 - frequency,
+                                "pattern": pattern,
+                                "severity": event.get("severity", "UNKNOWN"),
+                                "timestamp": event.get("timestamp", datetime.now()).isoformat()
+                                if isinstance(event.get("timestamp"), datetime)
+                                else str(event.get("timestamp", "")),
+                            }
+                        )
 
-        except Exception as e:
+        except Exception:
             outliers = []
 
         return outliers[:15]  # Limit to top 15 outliers
@@ -1330,7 +1465,7 @@ class MLPatternDetector:
             "trending_issues": [],
             "escalation_risk": "LOW",
             "pattern_stability": "STABLE",
-            "predictive_confidence": 0.0
+            "predictive_confidence": 0.0,
         }
 
         try:
@@ -1341,8 +1476,9 @@ class MLPatternDetector:
                 ts = e.get("timestamp", now)
                 try:
                     # Handle both naive and aware datetimes
-                    if hasattr(ts, 'tzinfo') and ts.tzinfo is not None:
+                    if hasattr(ts, "tzinfo") and ts.tzinfo is not None:
                         from datetime import timezone
+
                         diff = (datetime.now(timezone.utc) - ts).total_seconds()
                     else:
                         diff = (now - ts).total_seconds()
@@ -1354,14 +1490,18 @@ class MLPatternDetector:
             if len(recent_events) > len(self.events) * 0.5:  # More than 50% of events in last hour
                 indicators["trending_issues"].append("High event frequency in recent period")
                 # Only escalate risk if recent events include HIGH/CRITICAL severity
-                recent_high = [e for e in recent_events if e.get("severity") in ("HIGH", "CRITICAL")]
+                recent_high = [
+                    e for e in recent_events if e.get("severity") in ("HIGH", "CRITICAL")
+                ]
                 if recent_high:
                     indicators["escalation_risk"] = "HIGH"
 
             # Check for critical event trends
             critical_recent = [e for e in recent_events if e.get("severity") == "CRITICAL"]
             if len(critical_recent) > 2:
-                indicators["trending_issues"].append(f"{len(critical_recent)} critical events in last hour")
+                indicators["trending_issues"].append(
+                    f"{len(critical_recent)} critical events in last hour"
+                )
                 indicators["escalation_risk"] = "CRITICAL"
 
             # Pattern stability analysis
@@ -1404,27 +1544,34 @@ class LogMetricsIntegrator:
             # Extract error-related events that would correlate with log patterns
             error_events = [e for e in self.events if e.get("severity") in ("HIGH", "CRITICAL")]
             if error_events:
-                log_insights.append(f"{len(error_events)} high/critical severity events may have corresponding log entries")
+                log_insights.append(
+                    f"{len(error_events)} high/critical severity events"
+                    " may have corresponding log entries"
+                )
                 # Group by category for correlation
                 categories = {}
                 for e in error_events:
                     cat = e.get("category", "unknown")
                     categories[cat] = categories.get(cat, 0) + 1
                 for cat, count in sorted(categories.items(), key=lambda x: x[1], reverse=True)[:5]:
-                    correlations.append({
-                        "event_category": cat,
-                        "event_count": count,
-                        "suggestion": f"Check pod logs for {cat.lower()}-related errors"
-                    })
+                    correlations.append(
+                        {
+                            "event_category": cat,
+                            "event_count": count,
+                            "suggestion": f"Check pod logs for {cat.lower()}-related errors",
+                        }
+                    )
 
             if not log_insights:
                 log_insights.append("No high-severity events to correlate with logs")
-                log_insights.append("Use smart_summarize_pod_logs or semantic_log_search for direct log analysis")
+                log_insights.append(
+                    "Use smart_summarize_pod_logs or semantic_log_search for direct log analysis"
+                )
 
             return {
                 "log_correlation": "event_based",
                 "correlations": correlations,
-                "integration_insights": log_insights
+                "integration_insights": log_insights,
             }
 
         except Exception as e:
@@ -1441,19 +1588,39 @@ class LogMetricsIntegrator:
 
         # Analyze events for resource-related patterns instead of using fake metrics
         resource_events = {
-            "cpu": [e for e in self.events if any(kw in e.get("event_string", "").lower() for kw in ["cpu", "throttl", "resource limit"])],
-            "memory": [e for e in self.events if any(kw in e.get("event_string", "").lower() for kw in ["memory", "oom", "evict"])],
-            "network": [e for e in self.events if any(kw in e.get("event_string", "").lower() for kw in ["network", "connection", "timeout", "dns"])],
+            "cpu": [
+                e
+                for e in self.events
+                if any(
+                    kw in e.get("event_string", "").lower()
+                    for kw in ["cpu", "throttl", "resource limit"]
+                )
+            ],
+            "memory": [
+                e
+                for e in self.events
+                if any(kw in e.get("event_string", "").lower() for kw in ["memory", "oom", "evict"])
+            ],
+            "network": [
+                e
+                for e in self.events
+                if any(
+                    kw in e.get("event_string", "").lower()
+                    for kw in ["network", "connection", "timeout", "dns"]
+                )
+            ],
         }
 
         for resource_type, events in resource_events.items():
             if events:
-                correlations.append({
-                    "type": f"{resource_type}_event_correlation",
-                    "event_count": len(events),
-                    "description": f"{len(events)} {resource_type}-related event(s) detected",
-                    "sample_events": [e.get("event_string", "")[:150] for e in events[:3]]
-                })
+                correlations.append(
+                    {
+                        "type": f"{resource_type}_event_correlation",
+                        "event_count": len(events),
+                        "description": f"{len(events)} {resource_type}-related event(s) detected",
+                        "sample_events": [e.get("event_string", "")[:150] for e in events[:3]],
+                    }
+                )
 
         return {
             "metrics_correlation": "event_based",
@@ -1463,7 +1630,7 @@ class LogMetricsIntegrator:
                 "memory_related_events": len(resource_events["memory"]),
                 "network_related_events": len(resource_events["network"]),
             },
-            "note": "For real-time CPU/memory/disk metrics, use the prometheus_query tool directly"
+            "note": "For real-time CPU/memory/disk metrics, use the prometheus_query tool directly",
         }
 
 
@@ -1492,12 +1659,14 @@ class RunbookSuggestionEngine:
             if confidence > 0.5:
                 runbook = self._get_runbook_for_issue(issue_type)
                 if runbook:
-                    suggestions.append({
-                        "runbook": runbook,
-                        "confidence": confidence,
-                        "relevance_reason": self._explain_relevance(issue_type),
-                        "priority": self._calculate_priority(issue_type, confidence)
-                    })
+                    suggestions.append(
+                        {
+                            "runbook": runbook,
+                            "confidence": confidence,
+                            "relevance_reason": self._explain_relevance(issue_type),
+                            "priority": self._calculate_priority(issue_type, confidence),
+                        }
+                    )
 
         return sorted(suggestions, key=lambda x: x["priority"], reverse=True)[:5]
 
@@ -1513,10 +1682,10 @@ class RunbookSuggestionEngine:
                     "Verify resource limits and requests",
                     "Check application configuration",
                     "Review health check endpoints",
-                    "Validate container image"
+                    "Validate container image",
                 ],
                 "estimated_time": "15-30 minutes",
-                "severity": "HIGH"
+                "severity": "HIGH",
             },
             "memory_exhaustion": {
                 "title": "Memory Exhaustion Response",
@@ -1525,10 +1694,10 @@ class RunbookSuggestionEngine:
                     "Check for memory leaks in applications",
                     "Review memory limits configuration",
                     "Consider horizontal pod scaling",
-                    "Implement memory monitoring alerts"
+                    "Implement memory monitoring alerts",
                 ],
                 "estimated_time": "20-45 minutes",
-                "severity": "CRITICAL"
+                "severity": "CRITICAL",
             },
             "network_connectivity": {
                 "title": "Network Connectivity Issues",
@@ -1537,41 +1706,44 @@ class RunbookSuggestionEngine:
                     "Check network policies",
                     "Verify service endpoints",
                     "Review ingress configuration",
-                    "Test inter-pod communication"
+                    "Test inter-pod communication",
                 ],
                 "estimated_time": "25-40 minutes",
-                "severity": "HIGH"
+                "severity": "HIGH",
             },
             # ── Tekton / Konflux-specific runbooks ──
             "task_bundle_resolution": {
                 "title": "Tekton Task Bundle Resolution Failure",
                 "steps": [
                     "Check if the task bundle image exists: skopeo inspect docker://quay.io/konflux-ci/tekton-catalog/task-<name>:<version>",
-                    "Verify the task reference in .tekton/ pipeline YAML matches an available bundle",
+                    "Verify the task reference in .tekton/ pipeline YAML"
+                    " matches an available bundle",
                     "Check if the task version was recently deprecated or removed",
-                    "If using a pinned digest, verify it hasn't been garbage collected from the registry",
-                    "Check Tekton controller logs for bundle fetch errors"
+                    "If using a pinned digest, verify it hasn't been"
+                    " garbage collected from the registry",
+                    "Check Tekton controller logs for bundle fetch errors",
                 ],
                 "estimated_time": "10-15 minutes",
                 "severity": "HIGH",
                 "references": [
                     "https://konflux.pages.redhat.com/docs/users/troubleshooting/builds.html"
-                ]
+                ],
             },
             "push_snapshot_failure": {
                 "title": "Push Snapshot / OCI Artifact Failure",
                 "steps": [
-                    "Check if the .src source container tag exists (build-source-image may be skipped)",
+                    "Check if the .src source container tag exists"
+                    " (build-source-image may be skipped)",
                     "Verify the service account has push permissions to the quay.io image repo",
                     "Check quay.io organization quota and storage limits",
                     "Verify the image tag format matches what oras resolve expects",
-                    "If 'unauthorized' error, check robot account credentials in the push secret"
+                    "If 'unauthorized' error, check robot account credentials in the push secret",
                 ],
                 "estimated_time": "10-20 minutes",
                 "severity": "HIGH",
                 "references": [
                     "https://konflux.pages.redhat.com/docs/users/troubleshooting/releases.html"
-                ]
+                ],
             },
             "trusted_artifact_failure": {
                 "title": "Trusted Artifact Push/Pull Failure",
@@ -1579,28 +1751,29 @@ class RunbookSuggestionEngine:
                     "Verify the build service account has push access to OCI storage",
                     "Check if the quay.io repo exists for the component",
                     "For fork PRs, verify the .tekton/ config uses the correct service account",
-                    "Check quay.io rate limits or quota restrictions"
+                    "Check quay.io rate limits or quota restrictions",
                 ],
                 "estimated_time": "10-15 minutes",
                 "severity": "HIGH",
                 "references": [
                     "https://konflux.pages.redhat.com/docs/users/troubleshooting/builds.html"
-                ]
+                ],
             },
             "registry_auth_failure": {
                 "title": "Container Registry Authentication Failure",
                 "steps": [
                     "Check the pull/push secret referenced by the service account",
                     "Verify robot account credentials in quay.io are not expired",
-                    "Check if the image repository visibility matches expectations (public vs private)",
+                    "Check if the image repository visibility"
+                    " matches expectations (public vs private)",
                     "Verify the pac-gitauth secret is correctly configured",
-                    "For cross-namespace releases, check the RoleBinding for registry access"
+                    "For cross-namespace releases, check the RoleBinding for registry access",
                 ],
                 "estimated_time": "10-15 minutes",
                 "severity": "HIGH",
                 "references": [
                     "https://konflux.pages.redhat.com/docs/users/troubleshooting/builds.html"
-                ]
+                ],
             },
             "pyxis_registration_failure": {
                 "title": "Pyxis Image Registration Failure",
@@ -1608,28 +1781,29 @@ class RunbookSuggestionEngine:
                     "Check create-pyxis-image task logs for specific API errors",
                     "Verify Pyxis API credentials are configured in the release plan",
                     "Check if the image digest format is valid for Pyxis",
-                    "Verify network connectivity to the Pyxis API endpoint"
+                    "Verify network connectivity to the Pyxis API endpoint",
                 ],
                 "estimated_time": "15-20 minutes",
                 "severity": "MEDIUM",
                 "references": [
                     "https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release/release-service.md"
-                ]
+                ],
             },
             "pipeline_timeout": {
                 "title": "Pipeline Timeout or Long-Running Build",
                 "steps": [
-                    "Check which task is taking the longest (usually buildah or prefetch-dependencies)",
+                    "Check which task is taking the longest"
+                    " (usually buildah or prefetch-dependencies)",
                     "Verify Kueue workload admission - check if PLR was pending in queue",
                     "Check if the build node has sufficient CPU/memory available",
                     "For multi-platform builds, check if remote builder machines are available",
-                    "Review pipeline timeout setting (default 2h for builds)"
+                    "Review pipeline timeout setting (default 2h for builds)",
                 ],
                 "estimated_time": "15-25 minutes",
                 "severity": "MEDIUM",
                 "references": [
                     "https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md"
-                ]
+                ],
             },
             # ── OpenShift runbook links ──
             "etcd_issues": {
@@ -1638,14 +1812,14 @@ class RunbookSuggestionEngine:
                     "Check etcd pod logs for leader election or compaction errors",
                     "Monitor etcd disk latency and IOPS",
                     "Review etcd defragmentation schedule",
-                    "Check cluster operator status for etcd degradation"
+                    "Check cluster operator status for etcd degradation",
                 ],
                 "estimated_time": "20-30 minutes",
                 "severity": "CRITICAL",
                 "references": [
                     "https://github.com/openshift/runbooks/tree/master/alerts/cluster-etcd-operator",
-                    "https://docs.openshift.com/container-platform/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html"
-                ]
+                    "https://docs.openshift.com/container-platform/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html",
+                ],
             },
             "node_not_ready": {
                 "title": "Node Not Ready",
@@ -1653,14 +1827,14 @@ class RunbookSuggestionEngine:
                     "Check node conditions: kubectl get node <name> -o yaml",
                     "Review kubelet logs on the affected node",
                     "Check for disk pressure, memory pressure, or PID pressure",
-                    "Verify network connectivity to the API server from the node"
+                    "Verify network connectivity to the API server from the node",
                 ],
                 "estimated_time": "15-30 minutes",
                 "severity": "CRITICAL",
                 "references": [
                     "https://github.com/openshift/runbooks/tree/master/alerts/machine-config-operator",
-                    "https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html"
-                ]
+                    "https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html",
+                ],
             },
             "certificate_issues": {
                 "title": "TLS Certificate Issues",
@@ -1668,14 +1842,14 @@ class RunbookSuggestionEngine:
                     "Check certificate expiry dates across the cluster",
                     "Review certificate rotation status",
                     "Check for TLS handshake errors in ingress controller logs",
-                    "Verify cert-manager or cluster certificate operator health"
+                    "Verify cert-manager or cluster certificate operator health",
                 ],
                 "estimated_time": "20-40 minutes",
                 "severity": "HIGH",
                 "references": [
                     "https://docs.openshift.com/container-platform/latest/security/certificate_types_descriptions/index.html",
-                    "https://github.com/openshift/runbooks/tree/master/alerts/cluster-kube-apiserver-operator"
-                ]
+                    "https://github.com/openshift/runbooks/tree/master/alerts/cluster-kube-apiserver-operator",
+                ],
             },
             "machine_config_degraded": {
                 "title": "MachineConfigPool Degraded",
@@ -1683,14 +1857,14 @@ class RunbookSuggestionEngine:
                     "Check MachineConfigPool status and degraded message",
                     "Identify which nodes are not updated",
                     "Review machine-config-daemon logs on affected nodes",
-                    "Check if a recent MachineConfig change caused the degradation"
+                    "Check if a recent MachineConfig change caused the degradation",
                 ],
                 "estimated_time": "20-30 minutes",
                 "severity": "HIGH",
                 "references": [
                     "https://github.com/openshift/runbooks/tree/master/alerts/machine-config-operator",
-                    "https://docs.openshift.com/container-platform/latest/post_installation_configuration/machine-configuration-tasks.html"
-                ]
+                    "https://docs.openshift.com/container-platform/latest/post_installation_configuration/machine-configuration-tasks.html",
+                ],
             },
         }
 
@@ -1709,7 +1883,12 @@ class RunbookSuggestionEngine:
         # ── Tekton / Konflux-specific issues (check first for specificity) ──
 
         # Task bundle resolution failures
-        bundle_indicators = ["failed to resolve step ref", "failed to resolve task", "bundle", "resolver"]
+        bundle_indicators = [
+            "failed to resolve step ref",
+            "failed to resolve task",
+            "bundle",
+            "resolver",
+        ]
         bundle_score = sum(all_text.count(ind) for ind in bundle_indicators) / total_events
         if bundle_score > 0.05:
             issue_scores["task_bundle_resolution"] = min(1.0, bundle_score * 3)
@@ -1739,7 +1918,12 @@ class RunbookSuggestionEngine:
             issue_scores["pyxis_registration_failure"] = min(1.0, pyxis_score * 3)
 
         # Pipeline timeout / long-running
-        timeout_indicators = ["timed out", "deadline exceeded", "timeout", "pipelinerun was stopping"]
+        timeout_indicators = [
+            "timed out",
+            "deadline exceeded",
+            "timeout",
+            "pipelinerun was stopping",
+        ]
         timeout_score = sum(all_text.count(ind) for ind in timeout_indicators) / total_events
         if timeout_score > 0.05:
             issue_scores["pipeline_timeout"] = min(1.0, timeout_score * 2.5)
@@ -1753,19 +1937,36 @@ class RunbookSuggestionEngine:
             issue_scores["etcd_issues"] = min(1.0, etcd_score * 3)
 
         # Node not ready
-        node_indicators = ["nodenotready", "node not ready", "notready", "disk pressure", "memory pressure"]
+        node_indicators = [
+            "nodenotready",
+            "node not ready",
+            "notready",
+            "disk pressure",
+            "memory pressure",
+        ]
         node_score = sum(all_text.count(ind) for ind in node_indicators) / total_events
         if node_score > 0.05:
             issue_scores["node_not_ready"] = min(1.0, node_score * 3)
 
         # Certificate issues
-        cert_indicators = ["certificate expir", "tls handshake", "x509", "cert-manager", "certificate rotation"]
+        cert_indicators = [
+            "certificate expir",
+            "tls handshake",
+            "x509",
+            "cert-manager",
+            "certificate rotation",
+        ]
         cert_score = sum(all_text.count(ind) for ind in cert_indicators) / total_events
         if cert_score > 0.05:
             issue_scores["certificate_issues"] = min(1.0, cert_score * 3)
 
         # MachineConfigPool degraded
-        mcp_indicators = ["machineconfigpool", "machine-config", "mcdaemonstate", "degraded machine"]
+        mcp_indicators = [
+            "machineconfigpool",
+            "machine-config",
+            "mcdaemonstate",
+            "degraded machine",
+        ]
         mcp_score = sum(all_text.count(ind) for ind in mcp_indicators) / total_events
         if mcp_score > 0.05:
             issue_scores["machine_config_degraded"] = min(1.0, mcp_score * 3)
@@ -1773,8 +1974,15 @@ class RunbookSuggestionEngine:
         # ── Generic Kubernetes issues (fallback) ──
 
         # Pod crash issues — only if no Tekton-specific match was found
-        if not any(k in issue_scores for k in ["task_bundle_resolution", "push_snapshot_failure",
-                                                 "trusted_artifact_failure", "registry_auth_failure"]):
+        if not any(
+            k in issue_scores
+            for k in [
+                "task_bundle_resolution",
+                "push_snapshot_failure",
+                "trusted_artifact_failure",
+                "registry_auth_failure",
+            ]
+        ):
             crash_indicators = ["crash", "crashloopbackoff", "exit", "failed", "restart"]
             crash_score = sum(all_text.count(ind) for ind in crash_indicators) / total_events
             if crash_score > 0.1:
@@ -1805,13 +2013,23 @@ class RunbookSuggestionEngine:
             "pod_crash_loop": "Multiple pod failures and restart events detected",
             "memory_exhaustion": "OOM kills and memory-related events identified",
             "network_connectivity": "Network timeouts and connectivity issues found",
-            "task_bundle_resolution": "Tekton task bundle resolution errors detected (failed to resolve step ref)",
-            "push_snapshot_failure": "Push snapshot or OCI artifact resolution failures detected",
-            "trusted_artifact_failure": "Trusted artifact push/pull errors detected in build pipeline",
-            "registry_auth_failure": "Container registry authentication or authorization errors detected",
-            "pyxis_registration_failure": "Pyxis image registration failures detected in release pipeline",
+            "task_bundle_resolution": (
+                "Tekton task bundle resolution errors detected (failed to resolve step ref)"
+            ),
+            "push_snapshot_failure": ("Push snapshot or OCI artifact resolution failures detected"),
+            "trusted_artifact_failure": (
+                "Trusted artifact push/pull errors detected in build pipeline"
+            ),
+            "registry_auth_failure": (
+                "Container registry authentication or authorization errors detected"
+            ),
+            "pyxis_registration_failure": (
+                "Pyxis image registration failures detected in release pipeline"
+            ),
             "pipeline_timeout": "Pipeline timeout or long-running build detected",
-            "etcd_issues": "etcd cluster health events detected (leader election, compaction, or latency)",
+            "etcd_issues": (
+                "etcd cluster health events detected (leader election, compaction, or latency)"
+            ),
             "node_not_ready": "Node readiness issues detected (NotReady, disk/memory pressure)",
             "certificate_issues": "TLS certificate or handshake errors detected",
             "machine_config_degraded": "MachineConfigPool degradation events detected",
@@ -1823,12 +2041,7 @@ class RunbookSuggestionEngine:
         """Calculate priority score for runbook suggestion."""
 
         # Base priority on severity and confidence
-        severity_weights = {
-            "CRITICAL": 1.0,
-            "HIGH": 0.8,
-            "MEDIUM": 0.6,
-            "LOW": 0.4
-        }
+        severity_weights = {"CRITICAL": 1.0, "HIGH": 0.8, "MEDIUM": 0.6, "LOW": 0.4}
 
         runbook = self.runbooks.get(issue_type, {})
         severity = runbook.get("severity", "LOW")
@@ -1860,7 +2073,10 @@ def assess_overall_risk(analytics_result: Dict[str, Any]) -> Dict[str, Any]:
 
     # ML pattern risk
     ml_patterns = analytics_result.get("ml_patterns", {})
-    if "severity_escalation_patterns" in ml_patterns and ml_patterns["severity_escalation_patterns"]:
+    if (
+        "severity_escalation_patterns" in ml_patterns
+        and ml_patterns["severity_escalation_patterns"]
+    ):
         escalations = len(ml_patterns["severity_escalation_patterns"])
         risk_factors.append(f"Severity escalation patterns: {escalations}")
         risk_score += 0.25
@@ -1868,7 +2084,9 @@ def assess_overall_risk(analytics_result: Dict[str, Any]) -> Dict[str, Any]:
     # Correlation risk
     log_corr = analytics_result.get("log_correlation", {})
     if log_corr.get("correlations"):
-        error_correlations = [c for c in log_corr["correlations"] if c.get("type") == "error_correlation"]
+        error_correlations = [
+            c for c in log_corr["correlations"] if c.get("type") == "error_correlation"
+        ]
         if error_correlations:
             risk_factors.append("Strong log error correlations detected")
             risk_score += 0.2
@@ -1909,17 +2127,29 @@ def assess_overall_risk(analytics_result: Dict[str, Any]) -> Dict[str, Any]:
         if isinstance(pred, dict):
             escalation_risk = pred.get("escalation_risk", "LOW")
             # Overall risk should be at least one level below escalation risk
-            min_risk_for_escalation = {"LOW": "LOW", "MEDIUM": "LOW", "HIGH": "MEDIUM", "CRITICAL": "HIGH"}
+            min_risk_for_escalation = {
+                "LOW": "LOW",
+                "MEDIUM": "LOW",
+                "HIGH": "MEDIUM",
+                "CRITICAL": "HIGH",
+            }
             min_level = min_risk_for_escalation.get(escalation_risk, "LOW")
             if risk_rank.get(risk_level, 0) < risk_rank.get(min_level, 0):
                 risk_level = min_level
-                risk_factors.append(f"Risk elevated to {min_level} for consistency with {escalation_risk} escalation risk")
+                risk_factors.append(
+                    f"Risk elevated to {min_level} for consistency"
+                    f" with {escalation_risk} escalation risk"
+                )
 
     return {
         "overall_risk_level": risk_level,
         "risk_score": round(risk_score, 2),
         "risk_factors": risk_factors,
-        "mitigation_urgency": "IMMEDIATE" if risk_level == "CRITICAL" else "SOON" if risk_level == "HIGH" else "PLANNED"
+        "mitigation_urgency": "IMMEDIATE"
+        if risk_level == "CRITICAL"
+        else "SOON"
+        if risk_level == "HIGH"
+        else "PLANNED",
     }
 
 
@@ -1933,7 +2163,9 @@ def generate_strategic_recommendations(analytics_result: Dict[str, Any]) -> List
     risk_level = risk_assessment.get("overall_risk_level", "LOW")
 
     if risk_level == "CRITICAL":
-        recommendations.append("IMMEDIATE ACTION: Activate incident response procedures - critical issues detected")
+        recommendations.append(
+            "IMMEDIATE ACTION: Activate incident response procedures - critical issues detected"
+        )
         recommendations.append("Escalate to on-call team and stakeholders immediately")
     elif risk_level == "HIGH":
         recommendations.append("HIGH PRIORITY: Address identified issues within the next 2-4 hours")
@@ -1950,7 +2182,10 @@ def generate_strategic_recommendations(analytics_result: Dict[str, Any]) -> List
     runbooks = analytics_result.get("runbook_suggestions", [])
     if runbooks:
         top_runbook = runbooks[0]
-        recommendations.append(f"Execute: {top_runbook['runbook']['title']} (confidence: {top_runbook['confidence']:.1%})")
+        recommendations.append(
+            f"Execute: {top_runbook['runbook']['title']}"
+            f" (confidence: {top_runbook['confidence']:.1%})"
+        )
 
     # Correlation-based recommendations
     log_corr = analytics_result.get("log_correlation", {})
@@ -1967,12 +2202,16 @@ def generate_strategic_recommendations(analytics_result: Dict[str, Any]) -> List
 
     # Default recommendation if none generated
     if not recommendations:
-        recommendations.append("Continue monitoring - no immediate action required based on current analysis")
+        recommendations.append(
+            "Continue monitoring - no immediate action required based on current analysis"
+        )
 
     return recommendations
 
 
-async def generate_comprehensive_insights(analytics_result: Dict[str, Any], depth: str) -> List[str]:
+async def generate_comprehensive_insights(
+    analytics_result: Dict[str, Any], depth: str
+) -> List[str]:
     """Generate comprehensive insights from all analysis components."""
 
     insights = []
@@ -1981,11 +2220,19 @@ async def generate_comprehensive_insights(analytics_result: Dict[str, Any], dept
     ml_patterns = analytics_result.get("ml_patterns", {})
     if "temporal_anomalies" in ml_patterns and ml_patterns["temporal_anomalies"]:
         anomaly_count = len(ml_patterns["temporal_anomalies"])
-        insights.append(f"ML Analysis: Detected {anomaly_count} temporal anomalies indicating irregular event patterns")
+        insights.append(
+            f"ML Analysis: Detected {anomaly_count} temporal"
+            " anomalies indicating irregular event patterns"
+        )
 
-    if "severity_escalation_patterns" in ml_patterns and ml_patterns["severity_escalation_patterns"]:
+    if (
+        "severity_escalation_patterns" in ml_patterns
+        and ml_patterns["severity_escalation_patterns"]
+    ):
         escalation_count = len(ml_patterns["severity_escalation_patterns"])
-        insights.append(f"Escalation Alert: {escalation_count} severity escalation patterns detected")
+        insights.append(
+            f"Escalation Alert: {escalation_count} severity escalation patterns detected"
+        )
 
     # Correlation insights
     log_corr = analytics_result.get("log_correlation", {})
@@ -1993,30 +2240,45 @@ async def generate_comprehensive_insights(analytics_result: Dict[str, Any], dept
         correlations = log_corr.get("correlations", [])
         strong_correlations = [c for c in correlations if c.get("strength", 0) > 0.7]
         if strong_correlations:
-            insights.append(f"Log Integration: {len(strong_correlations)} strong correlations found between events and logs")
+            insights.append(
+                f"Log Integration: {len(strong_correlations)}"
+                " strong correlations found between"
+                " events and logs"
+            )
 
     metrics_corr = analytics_result.get("metrics_correlation", {})
     if metrics_corr.get("correlations"):
         cpu_issues = any(c["type"] == "cpu_correlation" for c in metrics_corr["correlations"])
         memory_issues = any(c["type"] == "memory_correlation" for c in metrics_corr["correlations"])
         if cpu_issues or memory_issues:
-            insights.append("Resource Correlation: Performance metrics confirm resource-related event patterns")
+            insights.append(
+                "Resource Correlation: Performance metrics confirm resource-related event patterns"
+            )
 
     # Runbook insights
     runbooks = analytics_result.get("runbook_suggestions", [])
     if runbooks:
         high_priority = [r for r in runbooks if r.get("priority", 0) > 0.7]
         if high_priority:
-            insights.append(f"Runbook Recommendations: {len(high_priority)} high-priority runbooks identified for immediate action")
+            insights.append(
+                f"Runbook Recommendations: {len(high_priority)}"
+                " high-priority runbooks identified"
+                " for immediate action"
+            )
 
     # Predictive insights
     if "predictive_indicators" in ml_patterns:
         pred = ml_patterns["predictive_indicators"]
         if isinstance(pred, dict) and "severity_trend" in pred:
             if pred["severity_trend"]["direction"] == "increasing":
-                insights.append("Predictive Alert: Severity trend is increasing - expect more critical events")
+                insights.append(
+                    "Predictive Alert: Severity trend is increasing - expect more critical events"
+                )
 
     if depth == "deep" and len(insights) < 3:
-        insights.append("Deep Analysis: Consider extending the analysis time window for more comprehensive patterns")
+        insights.append(
+            "Deep Analysis: Consider extending the analysis"
+            " time window for more comprehensive patterns"
+        )
 
     return insights

--- a/src/helpers/failure_analysis.py
+++ b/src/helpers/failure_analysis.py
@@ -7,10 +7,9 @@
 # ============================================================================
 
 from datetime import datetime
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any
 from kubernetes.client.rest import ApiException
 
-from .constants import PIPELINE_ANALYSIS_CONFIG
 
 # These functions will need K8s API clients and other function dependencies passed as parameters
 # k8s_core_api, k8s_custom_api, and various analysis functions are expected to be available
@@ -19,13 +18,14 @@ from .constants import PIPELINE_ANALYSIS_CONFIG
 # FAILURE CONTEXT IDENTIFICATION
 # ============================================================================
 
+
 async def identify_failure_context(
     failure_identifier: str,
     detect_tekton_namespaces_func,
     k8s_custom_api,
     k8s_core_api,
     logger,
-    namespace: str = None
+    namespace: str = None,
 ) -> Dict[str, Any]:
     """Identify the type and context of the failure.
 
@@ -52,10 +52,18 @@ async def identify_failure_context(
         for ns in all_namespaces:
             try:
                 pipeline_run = k8s_custom_api.get_namespaced_custom_object(
-                    group="tekton.dev", version="v1", namespace=ns,
-                    plural="pipelineruns", name=failure_identifier
+                    group="tekton.dev",
+                    version="v1",
+                    namespace=ns,
+                    plural="pipelineruns",
+                    name=failure_identifier,
                 )
-                return {"found": True, "type": "pipelinerun", "namespace": ns, "object": pipeline_run}
+                return {
+                    "found": True,
+                    "type": "pipelinerun",
+                    "namespace": ns,
+                    "object": pipeline_run,
+                }
             except ApiException:
                 continue
 
@@ -71,8 +79,11 @@ async def identify_failure_context(
         for ns in all_namespaces:
             try:
                 task_run = k8s_custom_api.get_namespaced_custom_object(
-                    group="tekton.dev", version="v1", namespace=ns,
-                    plural="taskruns", name=failure_identifier
+                    group="tekton.dev",
+                    version="v1",
+                    namespace=ns,
+                    plural="taskruns",
+                    name=failure_identifier,
                 )
                 return {"found": True, "type": "taskrun", "namespace": ns, "object": task_run}
             except ApiException:
@@ -84,11 +95,18 @@ async def identify_failure_context(
                 events = k8s_core_api.list_namespaced_event(
                     namespace=ns,
                     field_selector=f"involvedObject.name={failure_identifier}",
-                    limit=5
+                    limit=5,
                 )
                 if events.items:
-                    involved_kind = events.items[0].involved_object.kind or "unknown"
-                    logger.info(f"Resource '{failure_identifier}' not found directly but has {len(events.items)} events in {ns} (kind: {involved_kind})")
+                    involved_kind = (
+                        events.items[0].involved_object.kind or "unknown"
+                    )
+                    evt_count = len(events.items)
+                    logger.info(
+                        f"Resource '{failure_identifier}' not found "
+                        f"directly but has {evt_count} events "
+                        f"in {ns} (kind: {involved_kind})"
+                    )
                     return {
                         "found": True,
                         "type": involved_kind.lower(),
@@ -101,10 +119,12 @@ async def identify_failure_context(
                                 "reason": e.reason,
                                 "message": (e.message or "")[:200],
                                 "type": e.type,
-                                "last_timestamp": e.last_timestamp.isoformat() if e.last_timestamp else None,
+                                "last_timestamp": e.last_timestamp.isoformat()
+                                if e.last_timestamp
+                                else None,
                             }
                             for e in events.items
-                        ]
+                        ],
                     }
             except ApiException:
                 continue
@@ -116,16 +136,23 @@ async def identify_failure_context(
             "namespace": namespace,
             "object": None,
             "namespaces_searched": namespaces_searched,
-            "search_note": f"Resource '{failure_identifier}' not found as PipelineRun, Pod, or TaskRun in {len(all_namespaces)} namespace(s). It may have been garbage collected and events expired."
+            "search_note": (
+                f"Resource '{failure_identifier}' not found as "
+                f"PipelineRun, Pod, or TaskRun in "
+                f"{len(all_namespaces)} namespace(s). It may have "
+                f"been garbage collected and events expired."
+            ),
         }
 
     except Exception as e:
         logger.error(f"Error identifying failure context: {str(e)}")
         return {"found": False, "type": "error", "namespace": None, "object": None}
 
+
 # ============================================================================
 # SPECIFIC FAILURE ANALYSIS FUNCTIONS
 # ============================================================================
+
 
 async def analyze_pipeline_failure(
     namespace: str,
@@ -137,7 +164,7 @@ async def analyze_pipeline_failure(
     analyze_logs_func,
     detect_log_anomalies_func,
     analyze_pipeline_dependencies_func,
-    logger
+    logger,
 ) -> Dict[str, Any]:
     """Perform detailed analysis of a failed pipeline."""
     try:
@@ -149,7 +176,7 @@ async def analyze_pipeline_failure(
             "basic_analysis": basic_analysis,
             "logs_analyzed": {},
             "performance_data": {},
-            "dependency_analysis": {}
+            "dependency_analysis": {},
         }
 
         if depth in ["standard", "deep"]:
@@ -170,18 +197,21 @@ async def analyze_pipeline_failure(
                     anomaly_analysis = await detect_log_anomalies_func(log_content)
                     enhanced_data["logs_analyzed"][pod_name] = {
                         "log_analysis": log_analysis,
-                        "anomaly_analysis": anomaly_analysis
+                        "anomaly_analysis": anomaly_analysis,
                     }
 
         if depth == "deep":
             # Deep dependency analysis
-            enhanced_data["dependency_analysis"] = await analyze_pipeline_dependencies_func(namespace, pipeline_run)
+            enhanced_data["dependency_analysis"] = await analyze_pipeline_dependencies_func(
+                namespace, pipeline_run
+            )
 
         return enhanced_data
 
     except Exception as e:
         logger.error(f"Error analyzing pipeline failure: {str(e)}")
         return {"error": str(e), "logs_analyzed": {}}
+
 
 async def analyze_pod_failure(
     namespace: str,
@@ -192,7 +222,7 @@ async def analyze_pod_failure(
     analyze_logs_func,
     detect_log_anomalies_func,
     get_namespace_events_func,
-    logger
+    logger,
 ) -> Dict[str, Any]:
     """Perform detailed analysis of a failed pod."""
     try:
@@ -204,7 +234,7 @@ async def analyze_pod_failure(
             "pod_status": pod.status.phase,
             "container_statuses": [],
             "logs_analyzed": {},
-            "events_analysis": {}
+            "events_analysis": {},
         }
 
         # Analyze container statuses
@@ -214,7 +244,7 @@ async def analyze_pod_failure(
                     "name": container_status.name,
                     "ready": container_status.ready,
                     "restart_count": container_status.restart_count,
-                    "state": str(container_status.state)
+                    "state": str(container_status.state),
                 }
                 analysis["container_statuses"].append(status_info)
 
@@ -226,7 +256,7 @@ async def analyze_pod_failure(
         anomaly_analysis = await detect_log_anomalies_func(log_content)
         analysis["logs_analyzed"][pod_name] = {
             "log_analysis": log_analysis,
-            "anomaly_analysis": anomaly_analysis
+            "anomaly_analysis": anomaly_analysis,
         }
 
         if depth in ["standard", "deep"]:
@@ -240,12 +270,9 @@ async def analyze_pod_failure(
         logger.error(f"Error analyzing pod failure: {str(e)}")
         return {"error": str(e), "logs_analyzed": {}}
 
+
 async def analyze_generic_failure(
-    namespace: str,
-    identifier: str,
-    depth: str,
-    get_namespace_events_func,
-    logger
+    namespace: str, identifier: str, depth: str, get_namespace_events_func, logger
 ) -> Dict[str, Any]:
     """Perform generic failure analysis."""
     try:
@@ -254,7 +281,7 @@ async def analyze_generic_failure(
             "namespace": namespace,
             "events_analysis": {},
             "logs_analyzed": {},
-            "resource_analysis": {}
+            "resource_analysis": {},
         }
 
         # Get namespace events
@@ -267,16 +294,14 @@ async def analyze_generic_failure(
         logger.error(f"Error in generic failure analysis: {str(e)}")
         return {"error": str(e), "logs_analyzed": {}}
 
+
 # ============================================================================
 # TIMELINE AND RELATED FAILURE ANALYSIS
 # ============================================================================
 
+
 async def build_failure_timeline(
-    namespace: str,
-    identifier: str,
-    time_hours: int,
-    get_namespace_events_func,
-    logger
+    namespace: str, identifier: str, time_hours: int, get_namespace_events_func, logger
 ) -> List[Dict[str, str]]:
     """Build a detailed timeline of events leading to failure."""
     try:
@@ -288,13 +313,15 @@ async def build_failure_timeline(
         # Convert events to timeline format
         if "events" in events_data:
             for event in events_data["events"][:20]:  # Limit to 20 most recent
-                timeline.append({
-                    "timestamp": datetime.now().isoformat(),  # Would extract from event
-                    "event_type": "kubernetes_event",
-                    "component": "cluster",
-                    "description": str(event),
-                    "severity": "medium"
-                })
+                timeline.append(
+                    {
+                        "timestamp": datetime.now().isoformat(),  # Would extract from event
+                        "event_type": "kubernetes_event",
+                        "component": "cluster",
+                        "description": str(event),
+                        "severity": "medium",
+                    }
+                )
 
         # Sort by timestamp
         timeline.sort(key=lambda x: x["timestamp"], reverse=True)
@@ -304,13 +331,9 @@ async def build_failure_timeline(
         logger.error(f"Error building timeline: {str(e)}")
         return []
 
+
 async def find_related_failures(
-    namespace: str,
-    identifier: str,
-    time_hours: int,
-    depth: str,
-    list_pipelineruns_func,
-    logger
+    namespace: str, identifier: str, time_hours: int, depth: str, list_pipelineruns_func, logger
 ) -> List[Dict[str, Any]]:
     """Find related failures in the time window."""
     try:
@@ -322,11 +345,13 @@ async def find_related_failures(
         # Find failed runs in time window
         for pr in pipeline_runs[:10]:  # Limit search
             if pr.get("status") != "Succeeded":
-                related.append({
-                    "incident_id": pr.get("name", "unknown"),
-                    "similarity_score": 0.7,  # Would calculate based on error patterns
-                    "resolution_applied": "Investigation needed"
-                })
+                related.append(
+                    {
+                        "incident_id": pr.get("name", "unknown"),
+                        "similarity_score": 0.7,  # Would calculate based on error patterns
+                        "resolution_applied": "Investigation needed",
+                    }
+                )
 
         return related[:5]  # Return top 5 related incidents
 
@@ -334,9 +359,11 @@ async def find_related_failures(
         logger.error(f"Error finding related failures: {str(e)}")
         return []
 
+
 # ============================================================================
 # ADVANCED ROOT CAUSE ANALYSIS
 # ============================================================================
+
 
 async def perform_advanced_rca(
     primary_analysis: Dict,
@@ -344,7 +371,7 @@ async def perform_advanced_rca(
     related: List,
     depth: str,
     categorize_errors_func,
-    logger
+    logger,
 ) -> Dict[str, Any]:
     """Perform advanced root cause analysis using correlation algorithms."""
     try:
@@ -354,7 +381,8 @@ async def perform_advanced_rca(
             if "log_analysis" in log_data:
                 all_errors.extend(log_data["log_analysis"].get("error_patterns", []))
 
-        # Fallback: extract error info from basic_analysis when logs are unavailable (e.g. GC'd pods)
+        # Fallback: extract error info from basic_analysis when
+        # logs are unavailable (e.g. GC'd pods)
         if not all_errors:
             basic = primary_analysis.get("basic_analysis", {})
             if basic.get("overall_message"):
@@ -393,7 +421,7 @@ async def perform_advanced_rca(
                     "category": top_category[0],
                     "confidence": min(0.9, top_category[1] / 10.0),
                     "description": get_category_description(top_category[0]),
-                    "evidence": all_errors[:3]
+                    "evidence": all_errors[:3],
                 }
 
         # Final fallback: if still empty, derive cause from available context
@@ -401,19 +429,24 @@ async def perform_advanced_rca(
             primary_cause = {
                 "category": "unknown",
                 "confidence": 0.3,
-                "description": "Root cause could not be precisely categorized from available evidence",
-                "evidence": all_errors[:3]
+                "description": (
+                    "Root cause could not be precisely "
+                    "categorized from available evidence"
+                ),
+                "evidence": all_errors[:3],
             }
 
         # Find contributing factors
         contributing_factors = []
         for category, count in categories.items():
             if category != primary_cause.get("category") and count > 0:
-                contributing_factors.append({
-                    "factor": category,
-                    "impact_level": "high" if count > 3 else "medium",
-                    "description": get_category_description(category)
-                })
+                contributing_factors.append(
+                    {
+                        "factor": category,
+                        "impact_level": "high" if count > 3 else "medium",
+                        "description": get_category_description(category),
+                    }
+                )
 
         # Identify affected systems
         affected_systems = ["tekton-pipelines", "kubernetes-cluster"]
@@ -426,9 +459,9 @@ async def perform_advanced_rca(
             "root_cause_analysis": {
                 "primary_cause": primary_cause,
                 "contributing_factors": contributing_factors,
-                "affected_systems": affected_systems
+                "affected_systems": affected_systems,
             },
-            "dependency_failures": []
+            "dependency_failures": [],
         }
 
     except Exception as e:
@@ -437,20 +470,19 @@ async def perform_advanced_rca(
             "root_cause_analysis": {
                 "primary_cause": {"error": str(e)},
                 "contributing_factors": [],
-                "affected_systems": []
+                "affected_systems": [],
             },
-            "dependency_failures": []
+            "dependency_failures": [],
         }
+
 
 # ============================================================================
 # RESOURCE AND CONFIGURATION ANALYSIS
 # ============================================================================
 
+
 async def analyze_resource_constraints(
-    namespace: str,
-    identifier: str,
-    k8s_core_api,
-    logger
+    namespace: str, identifier: str, k8s_core_api, logger
 ) -> Dict[str, Any]:
     """Analyze resource constraints and usage patterns."""
     try:
@@ -459,11 +491,13 @@ async def analyze_resource_constraints(
             quotas = k8s_core_api.list_namespaced_resource_quota(namespace=namespace)
             quota_info = []
             for quota in quotas.items:
-                quota_info.append({
-                    "name": quota.metadata.name,
-                    "used": dict(quota.status.used) if quota.status.used else {},
-                    "hard": dict(quota.status.hard) if quota.status.hard else {}
-                })
+                quota_info.append(
+                    {
+                        "name": quota.metadata.name,
+                        "used": dict(quota.status.used) if quota.status.used else {},
+                        "hard": dict(quota.status.hard) if quota.status.hard else {},
+                    }
+                )
         except ApiException:
             quota_info = []
 
@@ -471,17 +505,16 @@ async def analyze_resource_constraints(
             "resource_quotas": quota_info,
             "memory_pressure": False,  # Would calculate from metrics
             "cpu_pressure": False,
-            "storage_issues": False
+            "storage_issues": False,
         }
 
     except Exception as e:
         logger.error(f"Error analyzing resource constraints: {str(e)}")
         return {}
 
+
 async def analyze_configuration_issues(
-    namespace: str,
-    identifier: str,
-    logger
+    namespace: str, identifier: str, logger
 ) -> List[Dict[str, str]]:
     """Analyze configuration issues."""
     try:
@@ -497,10 +530,7 @@ async def analyze_configuration_issues(
         return []
 
 
-async def analyze_pipeline_performance(
-    namespace: str,
-    limit: int = 50
-) -> Dict[str, Any]:
+async def analyze_pipeline_performance(namespace: str, limit: int = 50) -> Dict[str, Any]:
     """Analyze pipeline performance for the given namespace.
 
     Args:
@@ -519,36 +549,29 @@ async def analyze_pipeline_performance(
             "success_rate": None,
             "recent_trend": "unknown",
             "performance_baselines": {},
-            "note": "Performance data analysis placeholder - requires historical pipeline data"
+            "note": "Performance data analysis placeholder - requires historical pipeline data",
         }
 
     except Exception as e:
-        return {
-            "error": str(e),
-            "namespace": namespace
-        }
+        return {"error": str(e), "namespace": namespace}
 
 
 async def analyze_pipeline_dependencies(
-    namespace: str,
-    pipeline_run: str,
-    logger
+    namespace: str, pipeline_run: str, logger
 ) -> Dict[str, Any]:
     """Analyze pipeline dependencies for deep analysis."""
     try:
-        return {
-            "external_dependencies": [],
-            "internal_dependencies": [],
-            "version_conflicts": []
-        }
+        return {"external_dependencies": [], "internal_dependencies": [], "version_conflicts": []}
 
     except Exception as e:
         logger.error(f"Error analyzing dependencies: {str(e)}")
         return {}
 
+
 # ============================================================================
 # REMEDIATION PLANNING
 # ============================================================================
+
 
 async def generate_remediation_plan(
     root_cause_data: Dict,
@@ -556,7 +579,7 @@ async def generate_remediation_plan(
     resource_analysis: Dict,
     config_analysis: List,
     recommend_actions_func,
-    logger
+    logger,
 ) -> Dict[str, List[str]]:
     """Generate specific remediation recommendations."""
     try:
@@ -565,8 +588,10 @@ async def generate_remediation_plan(
 
         # Use existing recommendation logic
         analysis_for_recommendations = {
-            "probable_root_cause": root_cause_data["root_cause_analysis"]["primary_cause"].get("description", "Unknown"),
-            "failed_tasks": primary_analysis.get("basic_analysis", {}).get("failed_tasks", [])
+            "probable_root_cause": root_cause_data["root_cause_analysis"]["primary_cause"].get(
+                "description", "Unknown"
+            ),
+            "failed_tasks": primary_analysis.get("basic_analysis", {}).get("failed_tasks", []),
         }
 
         existing_recommendations = recommend_actions_func(analysis_for_recommendations)
@@ -575,32 +600,37 @@ async def generate_remediation_plan(
         # Add preventive measures based on root cause
         primary_cause = root_cause_data["root_cause_analysis"]["primary_cause"]
         if primary_cause.get("category") == "resource_limits":
-            preventive_measures.extend([
-                "Implement resource monitoring and alerting",
-                "Review and adjust resource requests/limits",
-                "Set up horizontal pod autoscaling where appropriate"
-            ])
+            preventive_measures.extend(
+                [
+                    "Implement resource monitoring and alerting",
+                    "Review and adjust resource requests/limits",
+                    "Set up horizontal pod autoscaling where appropriate",
+                ]
+            )
         elif primary_cause.get("category") == "network":
-            preventive_measures.extend([
-                "Implement network connectivity monitoring",
-                "Review and test network policies regularly",
-                "Set up dependency health checks"
-            ])
+            preventive_measures.extend(
+                [
+                    "Implement network connectivity monitoring",
+                    "Review and test network policies regularly",
+                    "Set up dependency health checks",
+                ]
+            )
 
-        return {
-            "immediate_actions": immediate_actions,
-            "preventive_measures": preventive_measures
-        }
+        return {"immediate_actions": immediate_actions, "preventive_measures": preventive_measures}
 
     except Exception as e:
         logger.error(f"Error generating remediation plan: {str(e)}")
         return {"immediate_actions": [], "preventive_measures": []}
 
+
 # ============================================================================
 # CONFIDENCE AND SCORING FUNCTIONS
 # ============================================================================
 
-def calculate_confidence_score(primary_analysis: Dict, root_cause_data: Dict, timeline: List) -> float:
+
+def calculate_confidence_score(
+    primary_analysis: Dict, root_cause_data: Dict, timeline: List
+) -> float:
     """Calculate confidence score for the RCA."""
     try:
         base_score = 0.5
@@ -620,7 +650,10 @@ def calculate_confidence_score(primary_analysis: Dict, root_cause_data: Dict, ti
     except Exception:
         return 0.3  # Low confidence fallback
 
-def calculate_failure_impact_score(primary_analysis: Dict, timeline: List, related: List) -> Dict[str, Any]:
+
+def calculate_failure_impact_score(
+    primary_analysis: Dict, timeline: List, related: List
+) -> Dict[str, Any]:
     """Calculate the impact score of the failure."""
 
     # Base impact from failure type
@@ -656,12 +689,14 @@ def calculate_failure_impact_score(primary_analysis: Dict, timeline: List, relat
         "impact_level": impact_level,
         "affected_components": affected_tasks,
         "related_incidents": related_count,
-        "timeline_density": timeline_count
+        "timeline_density": timeline_count,
     }
+
 
 # ============================================================================
 # UTILITY FUNCTIONS
 # ============================================================================
+
 
 def extract_log_content_string(pod_logs: Any) -> str:
     """Extract log content as string for analysis."""
@@ -677,6 +712,7 @@ def extract_log_content_string(pod_logs: Any) -> str:
 
     return log_content
 
+
 def get_category_description(category: str) -> str:
     """Get human-readable description for error categories."""
 
@@ -691,10 +727,11 @@ def get_category_description(category: str) -> str:
         "image": "Container image pull or registry issues",
         "volume": "Volume mount or storage access problems",
         "application": "Application-specific errors or bugs",
-        "unknown": "Unspecified or unclassified errors"
+        "unknown": "Unspecified or unclassified errors",
     }
 
     return descriptions.get(category, f"Issues related to {category}")
+
 
 def analyze_error_patterns(errors: List[str]) -> Dict[str, Any]:
     """Analyze patterns in error messages."""
@@ -708,7 +745,7 @@ def analyze_error_patterns(errors: List[str]) -> Dict[str, Any]:
         "FATAL": ["fatal", "panic", "crash", "abort"],
         "ERROR": ["error", "failed", "failure", "exception"],
         "WARNING": ["warning", "warn", "deprecated"],
-        "INFO": ["info", "notice", "debug"]
+        "INFO": ["info", "notice", "debug"],
     }
 
     for error in errors:
@@ -746,21 +783,25 @@ def analyze_error_patterns(errors: List[str]) -> Dict[str, Any]:
         "patterns": patterns,
         "frequency": error_counts,
         "severity": overall_severity,
-        "total_errors": len(errors)
+        "total_errors": len(errors),
     }
+
 
 # ============================================================================
 # FAILURE TREND ANALYSIS
 # ============================================================================
 
-def analyze_failure_trends(related_failures: List[Dict[str, Any]], timeline: List[Dict[str, str]]) -> Dict[str, Any]:
+
+def analyze_failure_trends(
+    related_failures: List[Dict[str, Any]], timeline: List[Dict[str, str]]
+) -> Dict[str, Any]:
     """Analyze trends in failure patterns."""
 
     trends = {
         "failure_frequency": "stable",
         "escalation_pattern": "none",
         "recurring_issues": [],
-        "trend_analysis": {}
+        "trend_analysis": {},
     }
 
     if not related_failures and not timeline:
@@ -799,10 +840,11 @@ def analyze_failure_trends(related_failures: List[Dict[str, Any]], timeline: Lis
     trends["trend_analysis"] = {
         "total_related_incidents": total_incidents,
         "timeline_events": timeline_events,
-        "analysis_confidence": calculate_trend_confidence(total_incidents, timeline_events)
+        "analysis_confidence": calculate_trend_confidence(total_incidents, timeline_events),
     }
 
     return trends
+
 
 def calculate_trend_confidence(incidents: int, events: int) -> float:
     """Calculate confidence in trend analysis."""
@@ -819,15 +861,14 @@ def calculate_trend_confidence(incidents: int, events: int) -> float:
     else:
         return 0.3
 
+
 # ============================================================================
 # FAILURE SEVERITY ASSESSMENT
 # ============================================================================
 
+
 def assess_failure_severity(
-    primary_analysis: Dict,
-    root_cause_data: Dict,
-    resource_analysis: Dict,
-    config_analysis: List
+    primary_analysis: Dict, root_cause_data: Dict, resource_analysis: Dict, config_analysis: List
 ) -> Dict[str, Any]:
     """Assess the overall severity of the failure."""
 
@@ -883,8 +924,9 @@ def assess_failure_severity(
         "severity_score": severity_score,
         "priority": priority,
         "severity_factors": severity_factors,
-        "recommended_response_time": get_response_time_recommendation(severity_level)
+        "recommended_response_time": get_response_time_recommendation(severity_level),
     }
+
 
 def get_response_time_recommendation(severity_level: str) -> str:
     """Get recommended response time based on severity."""
@@ -893,7 +935,7 @@ def get_response_time_recommendation(severity_level: str) -> str:
         "CRITICAL": "Immediate (within 15 minutes)",
         "HIGH": "Urgent (within 1 hour)",
         "MEDIUM": "Standard (within 4 hours)",
-        "LOW": "Normal (within 24 hours)"
+        "LOW": "Normal (within 24 hours)",
     }
 
     return response_times.get(severity_level, "Normal (within 24 hours)")
@@ -930,7 +972,11 @@ def generate_performance_impact_description(impact: float, scenario_type: str) -
         impact = abs(impact)
 
     magnitude = categorize_impact_severity(impact)
-    return f"{magnitude.title()} performance {direction} expected from {scenario_type.replace('_', ' ')} changes, with {severity}"
+    change_type = scenario_type.replace("_", " ")
+    return (
+        f"{magnitude.title()} performance {direction} expected "
+        f"from {change_type} changes, with {severity}"
+    )
 
 
 def generate_reliability_impact_description(impact: float, scenario_type: str) -> str:
@@ -944,7 +990,11 @@ def generate_reliability_impact_description(impact: float, scenario_type: str) -
         impact = abs(impact)
 
     magnitude = categorize_impact_severity(impact)
-    return f"{magnitude.title()} reliability {direction} anticipated from {scenario_type.replace('_', ' ')} changes, with {effects}"
+    change_type = scenario_type.replace("_", " ")
+    return (
+        f"{magnitude.title()} reliability {direction} anticipated "
+        f"from {change_type} changes, with {effects}"
+    )
 
 
 def generate_cost_impact_description(impact: float, scenario_type: str) -> str:
@@ -958,13 +1008,15 @@ def generate_cost_impact_description(impact: float, scenario_type: str) -> str:
         impact = abs(impact)
 
     magnitude = categorize_impact_severity(impact)
-    return f"{magnitude.title()} cost {direction} projected from {scenario_type.replace('_', ' ')} changes, with {effects}"
+    change_type = scenario_type.replace("_", " ")
+    return (
+        f"{magnitude.title()} cost {direction} projected "
+        f"from {change_type} changes, with {effects}"
+    )
 
 
 def analyze_system_impact(
-    simulation_results: Dict[str, Any],
-    baseline_data: Dict[str, Any],
-    scenario_type: str
+    simulation_results: Dict[str, Any], baseline_data: Dict[str, Any], scenario_type: str
 ) -> Dict[str, Any]:
     """Analyze the simulated impact on different system aspects."""
     try:
@@ -973,37 +1025,55 @@ def analyze_system_impact(
         # Analyze performance impact
         perf_stats = simulation_results.get("performance_impact", {})
         if perf_stats:
+            p5 = perf_stats.get("p5", 0)
+            p95 = perf_stats.get("p95", 0)
             impact_analysis["performance_impact"] = {
                 "expected_change": f"{perf_stats.get('mean', 0):.1%}",
                 "worst_case": f"{perf_stats.get('max', 0):.1%}",
                 "best_case": f"{perf_stats.get('min', 0):.1%}",
-                "confidence_interval": f"{perf_stats.get('p5', 0):.1%} to {perf_stats.get('p95', 0):.1%}",
-                "severity": categorize_impact_severity(perf_stats.get('mean', 0)),
-                "description": generate_performance_impact_description(perf_stats.get('mean', 0), scenario_type)
+                "confidence_interval": f"{p5:.1%} to {p95:.1%}",
+                "severity": categorize_impact_severity(
+                    perf_stats.get("mean", 0)
+                ),
+                "description": generate_performance_impact_description(
+                    perf_stats.get("mean", 0), scenario_type
+                ),
             }
 
         # Analyze reliability impact
         rel_stats = simulation_results.get("reliability_impact", {})
         if rel_stats:
+            p5 = rel_stats.get("p5", 0)
+            p95 = rel_stats.get("p95", 0)
             impact_analysis["reliability_impact"] = {
                 "expected_change": f"{rel_stats.get('mean', 0):.1%}",
                 "worst_case": f"{rel_stats.get('max', 0):.1%}",
                 "best_case": f"{rel_stats.get('min', 0):.1%}",
-                "confidence_interval": f"{rel_stats.get('p5', 0):.1%} to {rel_stats.get('p95', 0):.1%}",
-                "severity": categorize_impact_severity(rel_stats.get('mean', 0)),
-                "description": generate_reliability_impact_description(rel_stats.get('mean', 0), scenario_type)
+                "confidence_interval": f"{p5:.1%} to {p95:.1%}",
+                "severity": categorize_impact_severity(
+                    rel_stats.get("mean", 0)
+                ),
+                "description": generate_reliability_impact_description(
+                    rel_stats.get("mean", 0), scenario_type
+                ),
             }
 
         # Analyze cost impact
         cost_stats = simulation_results.get("cost_impact", {})
         if cost_stats:
+            p5 = cost_stats.get("p5", 0)
+            p95 = cost_stats.get("p95", 0)
             impact_analysis["cost_impact"] = {
                 "expected_change": f"{cost_stats.get('mean', 0):.1%}",
                 "worst_case": f"{cost_stats.get('max', 0):.1%}",
                 "best_case": f"{cost_stats.get('min', 0):.1%}",
-                "confidence_interval": f"{cost_stats.get('p5', 0):.1%} to {cost_stats.get('p95', 0):.1%}",
-                "severity": categorize_impact_severity(abs(cost_stats.get('mean', 0))),
-                "description": generate_cost_impact_description(cost_stats.get('mean', 0), scenario_type)
+                "confidence_interval": f"{p5:.1%} to {p95:.1%}",
+                "severity": categorize_impact_severity(
+                    abs(cost_stats.get("mean", 0))
+                ),
+                "description": generate_cost_impact_description(
+                    cost_stats.get("mean", 0), scenario_type
+                ),
             }
 
         return impact_analysis
@@ -1016,7 +1086,7 @@ def perform_risk_assessment(
     simulation_results: Dict[str, Any],
     impact_analysis: Dict[str, Any],
     affected_components: List[Dict[str, Any]],
-    risk_tolerance: str
+    risk_tolerance: str,
 ) -> Dict[str, Any]:
     """Perform comprehensive risk assessment of the proposed changes."""
     try:
@@ -1031,7 +1101,10 @@ def perform_risk_assessment(
             perf_score = min(100, abs(perf_mean) * 100)
             risk_scores.append(perf_score)
             if abs(perf_mean) > 0.15:
-                risk_factors.append(f"Significant performance impact: {perf_impact.get('expected_change', 'unknown')}")
+                risk_factors.append(
+                    "Significant performance impact: "
+                    f"{perf_impact.get('expected_change', 'unknown')}"
+                )
 
         # Assess reliability risk — always contribute a proportional score
         rel_impact = impact_analysis.get("reliability_impact", {})
@@ -1041,7 +1114,9 @@ def perform_risk_assessment(
             rel_score = min(100, abs(rel_mean) * 150)
             risk_scores.append(rel_score)
             if abs(rel_mean) >= 0.1:
-                risk_factors.append(f"Reliability impact: {rel_impact.get('expected_change', 'unknown')}")
+                risk_factors.append(
+                    f"Reliability impact: {rel_impact.get('expected_change', 'unknown')}"
+                )
 
         # Assess component risk
         critical_components = 0
@@ -1049,7 +1124,9 @@ def perform_risk_assessment(
             severity = component.get("severity", "LOW")
             if severity in ["CRITICAL", "HIGH", "critical", "high"]:
                 critical_components += 1
-                risk_factors.append(f"Critical component affected: {component.get('component', 'unknown')}")
+                risk_factors.append(
+                    f"Critical component affected: {component.get('component', 'unknown')}"
+                )
                 risk_scores.append(75 if severity.lower() == "high" else 100)
 
         # Calculate overall risk score
@@ -1064,7 +1141,7 @@ def perform_risk_assessment(
         risk_thresholds = {
             "conservative": {"high": 30, "medium": 15},
             "moderate": {"high": 50, "medium": 25},
-            "aggressive": {"high": 70, "medium": 40}
+            "aggressive": {"high": 70, "medium": 40},
         }
 
         thresholds = risk_thresholds.get(risk_tolerance.lower(), risk_thresholds["moderate"])
@@ -1083,7 +1160,9 @@ def perform_risk_assessment(
         if perf_impact and abs(perf_mean) > 0.3:
             rollback_factors.append("Significant performance changes")
 
-        rollback_complexity = "HIGH" if len(rollback_factors) > 1 else "MEDIUM" if rollback_factors else "LOW"
+        rollback_complexity = (
+            "HIGH" if len(rollback_factors) > 1 else "MEDIUM" if rollback_factors else "LOW"
+        )
 
         # Generate testing recommendations
         testing_recommendations = []
@@ -1105,8 +1184,8 @@ def perform_risk_assessment(
             "risk_breakdown": {
                 "performance_risk": perf_mean,
                 "reliability_risk": rel_mean,
-                "component_risk": critical_components
-            }
+                "component_risk": critical_components,
+            },
         }
 
     except Exception as e:
@@ -1115,7 +1194,7 @@ def perform_risk_assessment(
             "overall_risk": "unknown",
             "risk_factors": [f"Risk assessment error: {str(e)}"],
             "rollback_complexity": "unknown",
-            "testing_recommendations": ["Perform manual risk assessment due to simulation error"]
+            "testing_recommendations": ["Perform manual risk assessment due to simulation error"],
         }
 
 
@@ -1123,7 +1202,7 @@ def calculate_simulation_quality(
     baseline_data: Dict[str, Any],
     historical_data: Dict[str, Any],
     models: Dict[str, Any],
-    logger=None
+    logger=None,
 ) -> Dict[str, Any]:
     """Calculate quality metrics for the simulation."""
     try:
@@ -1132,8 +1211,14 @@ def calculate_simulation_quality(
         is_real_data = data_source == "prometheus"
 
         # Count all available data points across all metrics
-        metric_keys = ["cpu_utilization", "memory_utilization", "response_times",
-                       "error_rates", "throughput", "pipeline_durations"]
+        metric_keys = [
+            "cpu_utilization",
+            "memory_utilization",
+            "response_times",
+            "error_rates",
+            "throughput",
+            "pipeline_durations",
+        ]
         data_points_by_metric = {}
         total_data_points = 0
 
@@ -1176,18 +1261,21 @@ def calculate_simulation_quality(
         metrics_with_data = len(data_points_by_metric)
         metric_coverage = metrics_with_data / len(metric_keys) if metric_keys else 0
 
-        data_completeness = min(1.0, (
-            namespaces_analyzed * 0.05 +
-            nodes_analyzed * 0.03 +
-            metric_coverage * 0.5 +
-            (0.3 if is_real_data else 0)
-        ))
+        data_completeness = min(
+            1.0,
+            (
+                namespaces_analyzed * 0.05
+                + nodes_analyzed * 0.03
+                + metric_coverage * 0.5
+                + (0.3 if is_real_data else 0)
+            ),
+        )
 
         # Identify assumptions and limitations
         assumptions = [
             "Linear scaling relationships assumed for resource consumption",
             "Historical patterns representative of future behavior",
-            "No external dependencies or constraints considered"
+            "No external dependencies or constraints considered",
         ]
 
         if is_real_data:
@@ -1204,9 +1292,14 @@ def calculate_simulation_quality(
             if data_source == "synthetic_fallback":
                 limitations.append("Prometheus queries returned no data - using synthetic fallback")
             elif data_source == "synthetic_error_fallback":
-                limitations.append(f"Prometheus query error - using synthetic fallback: {historical_data.get('error', 'unknown')}")
+                limitations.append(
+                    "Prometheus query error - using synthetic "
+                    f"fallback: {historical_data.get('error', 'unknown')}"
+                )
 
-        limitations.append(f"Analysis covers {namespaces_analyzed} namespaces and {nodes_analyzed} nodes")
+        limitations.append(
+            f"Analysis covers {namespaces_analyzed} namespaces and {nodes_analyzed} nodes"
+        )
 
         if not is_real_data:
             limitations.append("Monte Carlo simulation uses simplified models with synthetic data")
@@ -1227,7 +1320,7 @@ def calculate_simulation_quality(
             "nodes_analyzed": nodes_analyzed,
             "assumptions": assumptions,
             "limitations": limitations,
-            "overall_quality": round((model_accuracy + data_completeness) / 2, 2)
+            "overall_quality": round((model_accuracy + data_completeness) / 2, 2),
         }
 
     except Exception as e:
@@ -1240,7 +1333,7 @@ def calculate_simulation_quality(
             "total_data_points": 0,
             "assumptions": ["Simulation quality calculation failed"],
             "limitations": [f"Quality assessment error: {str(e)}"],
-            "overall_quality": 0.0
+            "overall_quality": 0.0,
         }
 
 
@@ -1249,7 +1342,7 @@ def generate_simulation_recommendations(
     risk_assessment: Dict[str, Any],
     simulation_quality: Dict[str, Any],
     scenario_type: str,
-    logger=None
+    logger=None,
 ) -> Dict[str, Any]:
     """Generate actionable recommendations based on simulation results."""
     try:
@@ -1273,46 +1366,60 @@ def generate_simulation_recommendations(
         alternative_approaches = []
 
         if scenario_type == "scaling":
-            alternative_approaches.extend([
-                "Implement gradual scaling instead of immediate changes",
-                "Use horizontal pod autoscaling with conservative thresholds",
-                "Consider blue-green deployment for scaling changes"
-            ])
+            alternative_approaches.extend(
+                [
+                    "Implement gradual scaling instead of immediate changes",
+                    "Use horizontal pod autoscaling with conservative thresholds",
+                    "Consider blue-green deployment for scaling changes",
+                ]
+            )
         elif scenario_type == "resource_limits":
-            alternative_approaches.extend([
-                "Implement changes during low-traffic periods",
-                "Use resource quota increases instead of direct limit changes",
-                "Deploy changes to staging environment first"
-            ])
+            alternative_approaches.extend(
+                [
+                    "Implement changes during low-traffic periods",
+                    "Use resource quota increases instead of direct limit changes",
+                    "Deploy changes to staging environment first",
+                ]
+            )
         elif scenario_type == "configuration":
-            alternative_approaches.extend([
-                "Use canary deployments for configuration changes",
-                "Implement feature flags to control configuration rollout",
-                "Validate configurations in non-production environments"
-            ])
+            alternative_approaches.extend(
+                [
+                    "Use canary deployments for configuration changes",
+                    "Implement feature flags to control configuration rollout",
+                    "Validate configurations in non-production environments",
+                ]
+            )
         elif scenario_type == "deployment":
-            alternative_approaches.extend([
-                "Use rolling deployments with smaller batch sizes",
-                "Implement blue-green deployment strategy",
-                "Schedule deployment during maintenance windows"
-            ])
+            alternative_approaches.extend(
+                [
+                    "Use rolling deployments with smaller batch sizes",
+                    "Implement blue-green deployment strategy",
+                    "Schedule deployment during maintenance windows",
+                ]
+            )
 
         # Generate monitoring requirements
         monitoring_requirements = [
             "Monitor key performance metrics during and after changes",
             "Set up alerts for resource utilization thresholds",
-            "Track error rates and response times continuously"
+            "Track error rates and response times continuously",
         ]
 
         # Add specific monitoring based on risk factors
         risk_factors = risk_assessment.get("risk_factors", [])
         for factor in risk_factors:
             if "performance" in factor.lower():
-                monitoring_requirements.append("Implement detailed application performance monitoring")
+                monitoring_requirements.append(
+                    "Implement detailed application performance monitoring"
+                )
             elif "reliability" in factor.lower():
-                monitoring_requirements.append("Set up comprehensive health checks and SLA monitoring")
+                monitoring_requirements.append(
+                    "Set up comprehensive health checks and SLA monitoring"
+                )
             elif "component" in factor.lower():
-                monitoring_requirements.append("Monitor individual component health and dependencies")
+                monitoring_requirements.append(
+                    "Monitor individual component health and dependencies"
+                )
 
         return {
             "proceed": proceed,
@@ -1320,7 +1427,7 @@ def generate_simulation_recommendations(
             "alternative_approaches": alternative_approaches,
             "monitoring_requirements": monitoring_requirements,
             "quality_score": overall_quality,
-            "risk_level": overall_risk
+            "risk_level": overall_risk,
         }
 
     except Exception as e:
@@ -1331,5 +1438,5 @@ def generate_simulation_recommendations(
             "conditions": ["Manual review required due to simulation error"],
             "alternative_approaches": ["Conduct manual impact analysis"],
             "monitoring_requirements": ["Implement comprehensive monitoring"],
-            "error": str(e)
+            "error": str(e),
         }

--- a/src/helpers/log_analysis.py
+++ b/src/helpers/log_analysis.py
@@ -9,7 +9,7 @@
 import time
 import json
 import hashlib
-import asyncio
+import logging
 import re
 import pandas as pd
 import numpy as np
@@ -19,22 +19,27 @@ from dataclasses import dataclass
 from typing import Dict, List, Any, Optional, Tuple
 from collections import Counter, defaultdict
 
-from .constants import LOG_ANALYSIS_CONFIG
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # LOG ANALYSIS STRATEGY CLASSES
 # ============================================================================
 
+
 class LogAnalysisStrategy(Enum):
     """Available log analysis strategies."""
+
     SMART_SUMMARY = "smart_summary"
     STREAMING = "streaming"
     HYBRID = "hybrid"
     AUTO = "auto"
 
+
 @dataclass
 class LogAnalysisContext:
     """Context information for strategy selection."""
+
     log_size_estimate: int
     pod_name: str
     namespace: str
@@ -43,9 +48,11 @@ class LogAnalysisContext:
     time_sensitivity: bool
     follow_up_analysis: bool
 
+
 # ============================================================================
 # ANALYSIS CACHE CLASS
 # ============================================================================
+
 
 class AnalysisCache:
     """Simple in-memory cache for analysis results."""
@@ -60,7 +67,9 @@ class AnalysisCache:
         key_data = f"{namespace}:{pod_name}:{str(sorted(params.items()))}"
         return hashlib.md5(key_data.encode()).hexdigest()
 
-    def get(self, namespace: str, pod_name: str, params: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    def get(
+        self, namespace: str, pod_name: str, params: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """Retrieve cached result if available and still valid."""
         key = self._generate_key(namespace, pod_name, params)
 
@@ -78,7 +87,9 @@ class AnalysisCache:
 
         return None
 
-    def set(self, namespace: str, pod_name: str, params: Dict[str, Any], result: Dict[str, Any]) -> None:
+    def set(
+        self, namespace: str, pod_name: str, params: Dict[str, Any], result: Dict[str, Any]
+    ) -> None:
         """Store result in cache."""
         key = self._generate_key(namespace, pod_name, params)
 
@@ -91,15 +102,19 @@ class AnalysisCache:
         self.cache[key] = (result, time.time())
         self.access_times[key] = time.time()
 
+
 # ============================================================================
 # STRATEGY SELECTOR CLASS
 # ============================================================================
+
 
 class StrategySelector:
     """Intelligent strategy selector based on context and requirements."""
 
     @staticmethod
-    def select_strategy(context: LogAnalysisContext, available_strategies: List[LogAnalysisStrategy]) -> LogAnalysisStrategy:
+    def select_strategy(
+        context: LogAnalysisContext, available_strategies: List[LogAnalysisStrategy]
+    ) -> LogAnalysisStrategy:
         """Select optimal strategy based on context."""
 
         # High urgency always uses streaming for real-time insights
@@ -135,15 +150,22 @@ class StrategySelector:
         except Exception:
             return 10000  # Default safe estimate
 
+
 # ============================================================================
 # LOG STREAM PROCESSOR CLASS
 # ============================================================================
 
+
 class LogStreamProcessor:
     """Manages streaming log processing with pattern detection."""
 
-    def __init__(self, chunk_size: int = 5000, analysis_mode: str = "errors_and_warnings",
-                 max_patterns_per_chunk: int = 100, max_content_length: int = 200):
+    def __init__(
+        self,
+        chunk_size: int = 5000,
+        analysis_mode: str = "errors_and_warnings",
+        max_patterns_per_chunk: int = 100,
+        max_content_length: int = 200,
+    ):
         self.chunk_size = chunk_size
         self.analysis_mode = analysis_mode
         self.max_patterns_per_chunk = max_patterns_per_chunk
@@ -172,23 +194,27 @@ class LogStreamProcessor:
             "timestamp": datetime.utcnow().isoformat(),
             "patterns": chunk_patterns,
             "new_issues": self._identify_new_issues(chunk_patterns),
-            "chunk_summary": self._summarize_chunk(chunk_patterns)
+            "chunk_summary": self._summarize_chunk(chunk_patterns),
         }
 
         self.detected_patterns.append(result)
         self.current_chunk = []  # Reset chunk
         return result
 
-    def _extract_patterns_from_chunk(self, chunk_lines: List[str]) -> Dict[str, List[Dict[str, Any]]]:
+    def _extract_patterns_from_chunk(
+        self, chunk_lines: List[str]
+    ) -> Dict[str, List[Dict[str, Any]]]:
         """Extract patterns from a chunk of log lines with token-aware limits."""
         focus_areas = self._get_focus_areas_for_mode(self.analysis_mode)
         # Calculate max patterns per area based on total limit
-        max_per_area = max(10, self.max_patterns_per_chunk // len(focus_areas)) if focus_areas else 10
+        max_per_area = (
+            max(10, self.max_patterns_per_chunk // len(focus_areas)) if focus_areas else 10
+        )
         return extract_log_patterns(
             chunk_lines,
             focus_areas,
             max_patterns_per_area=max_per_area,
-            max_content_length=self.max_content_length
+            max_content_length=self.max_content_length,
         )
 
     def _get_focus_areas_for_mode(self, mode: str) -> List[str]:
@@ -197,11 +223,21 @@ class LogStreamProcessor:
             "errors_only": ["errors"],
             "errors_and_warnings": ["errors", "warnings"],
             "full_analysis": ["errors", "warnings", "performance", "exceptions", "timeouts"],
-            "custom_patterns": ["errors", "warnings", "performance", "exceptions", "timeouts", "memory_issues", "network_issues"]
+            "custom_patterns": [
+                "errors",
+                "warnings",
+                "performance",
+                "exceptions",
+                "timeouts",
+                "memory_issues",
+                "network_issues",
+            ],
         }
         return mode_mappings.get(mode, ["errors", "warnings"])
 
-    def _identify_new_issues(self, chunk_patterns: Dict[str, List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    def _identify_new_issues(
+        self, chunk_patterns: Dict[str, List[Dict[str, Any]]]
+    ) -> List[Dict[str, Any]]:
         """Identify new issues not seen in previous chunks (limited to prevent token overflow)."""
         new_issues = []
         max_new_issues = 20  # Limit new issues per chunk to prevent token overflow
@@ -221,11 +257,13 @@ class LogStreamProcessor:
                 )
 
                 if not seen_before:
-                    new_issues.append({
-                        "category": category,
-                        "pattern": pattern,
-                        "severity": self._assess_severity(category, pattern)
-                    })
+                    new_issues.append(
+                        {
+                            "category": category,
+                            "pattern": pattern,
+                            "severity": self._assess_severity(category, pattern),
+                        }
+                    )
 
             if len(new_issues) >= max_new_issues:
                 break
@@ -236,9 +274,13 @@ class LogStreamProcessor:
         """Assess severity of an issue."""
         content = pattern["content"].lower()
 
-        if category in ["exceptions", "memory_issues"] or any(word in content for word in ["fatal", "panic", "crash"]):
+        if category in ["exceptions", "memory_issues"] or any(
+            word in content for word in ["fatal", "panic", "crash"]
+        ):
             return "critical"
-        elif category in ["errors", "timeouts"] or any(word in content for word in ["error", "failed", "timeout"]):
+        elif category in ["errors", "timeouts"] or any(
+            word in content for word in ["error", "failed", "timeout"]
+        ):
             return "high"
         elif category in ["warnings", "performance"]:
             return "medium"
@@ -253,9 +295,17 @@ class LogStreamProcessor:
             "total_issues": total_issues,
             "error_count": len(chunk_patterns.get("errors", [])),
             "warning_count": len(chunk_patterns.get("warnings", [])),
-            "critical_issues": len([p for patterns in chunk_patterns.values() for p in patterns
-                                 if self._assess_severity("", p) == "critical"]),
-            "dominant_category": max(chunk_patterns.keys(), key=lambda k: len(chunk_patterns[k])) if chunk_patterns else None
+            "critical_issues": len(
+                [
+                    p
+                    for patterns in chunk_patterns.values()
+                    for p in patterns
+                    if self._assess_severity("", p) == "critical"
+                ]
+            ),
+            "dominant_category": max(chunk_patterns.keys(), key=lambda k: len(chunk_patterns[k]))
+            if chunk_patterns
+            else None,
         }
 
     def finalize(self) -> Optional[Dict[str, Any]]:
@@ -264,19 +314,21 @@ class LogStreamProcessor:
             return self._analyze_chunk()
         return None
 
+
 # ============================================================================
 # LOG PATTERN EXTRACTION FUNCTIONS
 # ============================================================================
+
 
 def _get_structured_log_level(line: str) -> Optional[str]:
     """Extract severity from structured JSON logs, returning None for non-JSON."""
     try:
         content = line.strip()
         # Strip leading timestamp if present
-        timestamp_match = re.match(r'^\d{4}-\d{2}-\d{2}T[\d:.]+Z?\s*', content)
+        timestamp_match = re.match(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z?\s*", content)
         if timestamp_match:
-            content = content[timestamp_match.end():]
-        if content.startswith('{'):
+            content = content[timestamp_match.end() :]
+        if content.startswith("{"):
             parsed = json.loads(content)
             level = (parsed.get("level") or parsed.get("severity") or "").lower()
             if level in ("info", "debug", "warn", "warning", "error", "fatal", "panic"):
@@ -286,7 +338,12 @@ def _get_structured_log_level(line: str) -> Optional[str]:
     return None
 
 
-def extract_log_patterns(log_lines: List[str], focus_areas: List[str], max_patterns_per_area: int = 50, max_content_length: int = 200) -> Dict[str, List[Dict[str, Any]]]:
+def extract_log_patterns(
+    log_lines: List[str],
+    focus_areas: List[str],
+    max_patterns_per_area: int = 50,
+    max_content_length: int = 200,
+) -> Dict[str, List[Dict[str, Any]]]:
     """Extract patterns from log lines based on focus areas.
 
     Args:
@@ -301,50 +358,50 @@ def extract_log_patterns(log_lines: List[str], focus_areas: List[str], max_patte
     # Define pattern regex for different categories
     pattern_regex = {
         "errors": [
-            r'(?i)error[:|\s](.{0,100})',
-            r'(?i)exception[:|\s](.{0,100})',
-            r'(?i)failed[:|\s](.{0,100})',
-            r'(?i)failure[:|\s](.{0,100})'
+            r"(?i)error[:|\s](.{0,100})",
+            r"(?i)exception[:|\s](.{0,100})",
+            r"(?i)failed[:|\s](.{0,100})",
+            r"(?i)failure[:|\s](.{0,100})",
         ],
         "warnings": [
-            r'(?i)warning[:|\s](.{0,100})',
-            r'(?i)warn[:|\s](.{0,100})',
-            r'(?i)deprecated[:|\s](.{0,100})'
+            r"(?i)warning[:|\s](.{0,100})",
+            r"(?i)warn[:|\s](.{0,100})",
+            r"(?i)deprecated[:|\s](.{0,100})",
         ],
         "performance": [
-            r'(?i)slow[:|\s](.{0,100})',
-            r'(?i)timeout[:|\s](.{0,100})',
-            r'(?i)latency[:|\s](.{0,100})',
-            r'(?i)bottleneck[:|\s](.{0,100})'
+            r"(?i)slow[:|\s](.{0,100})",
+            r"(?i)timeout[:|\s](.{0,100})",
+            r"(?i)latency[:|\s](.{0,100})",
+            r"(?i)bottleneck[:|\s](.{0,100})",
         ],
         "exceptions": [
-            r'(?i)panic[:|\s](.{0,100})',
-            r'(?i)stacktrace[:|\s](.{0,100})',
-            r'(?i)traceback[:|\s](.{0,100})'
+            r"(?i)panic[:|\s](.{0,100})",
+            r"(?i)stacktrace[:|\s](.{0,100})",
+            r"(?i)traceback[:|\s](.{0,100})",
         ],
         "timeouts": [
-            r'(?i)timeout[:|\s](.{0,100})',
-            r'(?i)timed out[:|\s](.{0,100})',
-            r'(?i)deadline exceeded[:|\s](.{0,100})'
+            r"(?i)timeout[:|\s](.{0,100})",
+            r"(?i)timed out[:|\s](.{0,100})",
+            r"(?i)deadline exceeded[:|\s](.{0,100})",
         ],
         "memory_issues": [
-            r'(?i)out of memory[:|\s](.{0,100})',
-            r'(?i)oom[:|\s](.{0,100})',
-            r'(?i)memory leak[:|\s](.{0,100})'
+            r"(?i)out of memory[:|\s](.{0,100})",
+            r"(?i)oom[:|\s](.{0,100})",
+            r"(?i)memory leak[:|\s](.{0,100})",
         ],
         "network_issues": [
-            r'(?i)connection refused[:|\s](.{0,100})',
-            r'(?i)dns[:|\s](.{0,100})',
-            r'(?i)network unreachable[:|\s](.{0,100})'
+            r"(?i)connection refused[:|\s](.{0,100})",
+            r"(?i)dns[:|\s](.{0,100})",
+            r"(?i)network unreachable[:|\s](.{0,100})",
         ],
         "security": [
-            r'(?i)tls[:|\s](.{0,100})',
-            r'(?i)certificate[:|\s](.{0,100})',
-            r'(?i)ssl[:|\s](.{0,100})',
-            r'(?i)x509[:|\s](.{0,100})',
-            r'(?i)permission[:|\s](.{0,100})',
-            r'(?i)forbidden[:|\s](.{0,100})'
-        ]
+            r"(?i)tls[:|\s](.{0,100})",
+            r"(?i)certificate[:|\s](.{0,100})",
+            r"(?i)ssl[:|\s](.{0,100})",
+            r"(?i)x509[:|\s](.{0,100})",
+            r"(?i)permission[:|\s](.{0,100})",
+            r"(?i)forbidden[:|\s](.{0,100})",
+        ],
     }
 
     # Areas where structured JSON log level should gate pattern matching.
@@ -380,18 +437,24 @@ def extract_log_patterns(log_lines: List[str], focus_areas: List[str], max_patte
 
                         # Deduplicate: check if a similar pattern was already captured
                         # Use the matched_text as a signature (strip variable parts like IPs/ports)
-                        dedup_sig = re.sub(r'\d+\.\d+\.\d+\.\d+:\d+', '<ip:port>', matched_text)
-                        dedup_sig = re.sub(r'[0-9a-f]{8,}', '<id>', dedup_sig)
+                        dedup_sig = re.sub(r"\d+\.\d+\.\d+\.\d+:\d+", "<ip:port>", matched_text)
+                        dedup_sig = re.sub(r"[0-9a-f]{8,}", "<id>", dedup_sig)
                         existing_sigs = [
-                            re.sub(r'\d+\.\d+\.\d+\.\d+:\d+', '<ip:port>',
-                            re.sub(r'[0-9a-f]{8,}', '<id>', p.get("matched_text", "")))
+                            re.sub(
+                                r"\d+\.\d+\.\d+\.\d+:\d+",
+                                "<ip:port>",
+                                re.sub(r"[0-9a-f]{8,}", "<id>", p.get("matched_text", "")),
+                            )
                             for p in patterns[area]
                         ]
                         if dedup_sig in existing_sigs:
                             # Increment count on the existing pattern instead
                             for p in patterns[area]:
-                                p_sig = re.sub(r'\d+\.\d+\.\d+\.\d+:\d+', '<ip:port>',
-                                        re.sub(r'[0-9a-f]{8,}', '<id>', p.get("matched_text", "")))
+                                p_sig = re.sub(
+                                    r"\d+\.\d+\.\d+\.\d+:\d+",
+                                    "<ip:port>",
+                                    re.sub(r"[0-9a-f]{8,}", "<id>", p.get("matched_text", "")),
+                                )
                                 if p_sig == dedup_sig:
                                     p["occurrence_count"] = p.get("occurrence_count", 1) + 1
                                     break
@@ -401,27 +464,30 @@ def extract_log_patterns(log_lines: List[str], focus_areas: List[str], max_patte
                         truncated_content = line.strip()[:max_content_length]
                         if len(line.strip()) > max_content_length:
                             truncated_content += "..."
-                        patterns[area].append({
-                            "line_number": line_num,
-                            "timestamp": timestamp,
-                            "content": truncated_content,
-                            "matched_text": matched_text,
-                            "severity": assess_log_severity(line),
-                            "occurrence_count": 1
-                        })
+                        patterns[area].append(
+                            {
+                                "line_number": line_num,
+                                "timestamp": timestamp,
+                                "content": truncated_content,
+                                "matched_text": matched_text,
+                                "severity": assess_log_severity(line),
+                                "occurrence_count": 1,
+                            }
+                        )
 
     return patterns
+
 
 def extract_timestamp(log_line: str) -> Optional[str]:
     """Extract timestamp from log line using common patterns."""
 
     # Common timestamp patterns
     timestamp_patterns = [
-        r'(\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)',  # ISO format
-        r'(\d{2}/\d{2}/\d{4}\s\d{2}:\d{2}:\d{2})',  # MM/DD/YYYY HH:MM:SS
-        r'(\w{3}\s\d{1,2}\s\d{2}:\d{2}:\d{2})',     # Mon DD HH:MM:SS
-        r'(\d{2}-\d{2}\s\d{2}:\d{2}:\d{2})',        # MM-DD HH:MM:SS
-        r'(\d{10,13})',                              # Unix timestamp
+        r"(\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)",  # ISO format
+        r"(\d{2}/\d{2}/\d{4}\s\d{2}:\d{2}:\d{2})",  # MM/DD/YYYY HH:MM:SS
+        r"(\w{3}\s\d{1,2}\s\d{2}:\d{2}:\d{2})",  # Mon DD HH:MM:SS
+        r"(\d{2}-\d{2}\s\d{2}:\d{2}:\d{2})",  # MM-DD HH:MM:SS
+        r"(\d{10,13})",  # Unix timestamp
     ]
 
     for pattern in timestamp_patterns:
@@ -430,6 +496,7 @@ def extract_timestamp(log_line: str) -> Optional[str]:
             return match.group(1)
 
     return None
+
 
 def assess_log_severity(log_line: str) -> str:
     """Assess the severity of a log line."""
@@ -451,7 +518,13 @@ def assess_log_severity(log_line: str) -> str:
     # Low severity (info, debug, etc.)
     return "low"
 
-def sample_logs_by_time(log_lines: List[str], time_segments: int, max_logs_per_segment: int = 100, max_line_length: int = 300) -> Dict[str, List[str]]:
+
+def sample_logs_by_time(
+    log_lines: List[str],
+    time_segments: int,
+    max_logs_per_segment: int = 100,
+    max_line_length: int = 300,
+) -> Dict[str, List[str]]:
     """Sample logs by dividing into time segments with token-aware limits.
 
     Args:
@@ -477,7 +550,12 @@ def sample_logs_by_time(log_lines: List[str], time_segments: int, max_logs_per_s
     if not timestamped_logs:
         # Limit even the fallback case
         limited_logs = log_lines[:max_logs_per_segment]
-        return {"segment_1": [line[:max_line_length] + ("..." if len(line) > max_line_length else "") for line in limited_logs]}
+        return {
+            "segment_1": [
+                line[:max_line_length] + ("..." if len(line) > max_line_length else "")
+                for line in limited_logs
+            ]
+        }
 
     # Sort by timestamp
     timestamped_logs.sort(key=lambda x: x[0])
@@ -502,7 +580,7 @@ def sample_logs_by_time(log_lines: List[str], time_segments: int, max_logs_per_s
 
             first_logs = segment_logs_raw[:first_count]
             middle_start = len(segment_logs_raw) // 2 - middle_count // 2
-            middle_logs = segment_logs_raw[middle_start:middle_start + middle_count]
+            middle_logs = segment_logs_raw[middle_start : middle_start + middle_count]
             last_logs = segment_logs_raw[-last_count:]
 
             segment_logs_raw = first_logs + middle_logs + last_logs
@@ -517,9 +595,11 @@ def sample_logs_by_time(log_lines: List[str], time_segments: int, max_logs_per_s
 
     return segments
 
+
 # ============================================================================
 # STREAMING ANALYSIS FUNCTIONS
 # ============================================================================
+
 
 def generate_streaming_summary(chunk_results: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Generate summary from streaming chunk results."""
@@ -529,8 +609,7 @@ def generate_streaming_summary(chunk_results: List[Dict[str, Any]]) -> Dict[str,
 
     total_lines = sum(chunk.get("lines_processed", 0) for chunk in chunk_results)
     total_issues = sum(
-        chunk.get("chunk_summary", {}).get("total_issues", 0)
-        for chunk in chunk_results
+        chunk.get("chunk_summary", {}).get("total_issues", 0) for chunk in chunk_results
     )
 
     # Aggregate patterns across chunks
@@ -553,9 +632,10 @@ def generate_streaming_summary(chunk_results: List[Dict[str, Any]]) -> Dict[str,
         "most_common_errors": dict(error_counter.most_common(5)),
         "analysis_timespan": {
             "first_chunk": chunk_results[0].get("timestamp"),
-            "last_chunk": chunk_results[-1].get("timestamp")
-        }
+            "last_chunk": chunk_results[-1].get("timestamp"),
+        },
     }
+
 
 def analyze_trending_patterns(chunk_results: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Analyze patterns that are trending across chunks."""
@@ -571,10 +651,7 @@ def analyze_trending_patterns(chunk_results: List[Dict[str, Any]]) -> Dict[str, 
         timestamp = chunk.get("timestamp", datetime.now().isoformat())
 
         for category, patterns in chunk_patterns.items():
-            pattern_trends[category].append({
-                "timestamp": timestamp,
-                "count": len(patterns)
-            })
+            pattern_trends[category].append({"timestamp": timestamp, "count": len(patterns)})
 
     # Identify increasing trends
     trending_up = {}
@@ -587,15 +664,15 @@ def analyze_trending_patterns(chunk_results: List[Dict[str, Any]]) -> Dict[str, 
                 trending_up[category] = {
                     "recent_average": recent_avg,
                     "earlier_average": earlier_avg,
-                    "trend_strength": recent_avg / max(earlier_avg, 0.1)
+                    "trend_strength": recent_avg / max(earlier_avg, 0.1),
                 }
 
-    return {
-        "trending_up": trending_up,
-        "pattern_trends": dict(pattern_trends)
-    }
+    return {"trending_up": trending_up, "pattern_trends": dict(pattern_trends)}
 
-def generate_streaming_recommendations(overall_summary: Dict[str, Any], trending_patterns: Dict[str, Any]) -> List[str]:
+
+def generate_streaming_recommendations(
+    overall_summary: Dict[str, Any], trending_patterns: Dict[str, Any]
+) -> List[str]:
     """Generate recommendations based on streaming analysis."""
 
     recommendations = []
@@ -603,9 +680,13 @@ def generate_streaming_recommendations(overall_summary: Dict[str, Any], trending
     # High issue count recommendations
     total_issues = overall_summary.get("total_issues_found", 0)
     if total_issues > 50:
-        recommendations.append(f"High issue count detected ({total_issues}). Consider reviewing application stability.")
+        recommendations.append(
+            f"High issue count detected ({total_issues}). Consider reviewing application stability."
+        )
     elif total_issues > 10:
-        recommendations.append(f"Moderate issue count ({total_issues}). Review error patterns for recurring problems.")
+        recommendations.append(
+            f"Moderate issue count ({total_issues}). Review error patterns for recurring problems."
+        )
 
     # Trending pattern recommendations
     trending_up = trending_patterns.get("trending_up", {})
@@ -613,37 +694,50 @@ def generate_streaming_recommendations(overall_summary: Dict[str, Any], trending
         recommendations.append("Error rate is increasing. Immediate investigation recommended.")
 
     if "memory_issues" in trending_up:
-        recommendations.append("Memory issues trending up. Check for memory leaks or increase resource limits.")
+        recommendations.append(
+            "Memory issues trending up. Check for memory leaks or increase resource limits."
+        )
 
     if "timeouts" in trending_up:
-        recommendations.append("Timeout patterns increasing. Review network connectivity and service dependencies.")
+        recommendations.append(
+            "Timeout patterns increasing. Review network connectivity and service dependencies."
+        )
 
     # Pattern-specific recommendations
     common_errors = overall_summary.get("most_common_errors", {})
     for error, count in common_errors.items():
         if count > 10:
-            recommendations.append(f"Frequent error pattern detected: '{error}' ({count} occurrences)")
+            recommendations.append(
+                f"Frequent error pattern detected: '{error}' ({count} occurrences)"
+            )
 
     if not recommendations:
         if total_issues == 0:
             recommendations.append("No critical patterns detected. System appears stable.")
         else:
-            recommendations.append(f"{total_issues} issue(s) detected but no critical patterns identified. Review logs for details.")
+            recommendations.append(
+                f"{total_issues} issue(s) detected but no critical "
+                "patterns identified. Review logs for details."
+            )
 
     return recommendations
+
 
 # ============================================================================
 # ANALYSIS COMBINATION FUNCTIONS
 # ============================================================================
 
-def combine_analysis_results(summary_result: Dict[str, Any], streaming_result: Dict[str, Any]) -> Dict[str, Any]:
+
+def combine_analysis_results(
+    summary_result: Dict[str, Any], streaming_result: Dict[str, Any]
+) -> Dict[str, Any]:
     """Combine results from summary and streaming analysis."""
 
     combined = {
         "analysis_type": "hybrid",
         "summary_analysis": summary_result,
         "streaming_analysis": streaming_result,
-        "combined_insights": []
+        "combined_insights": [],
     }
 
     # Generate combined insights
@@ -654,53 +748,73 @@ def combine_analysis_results(summary_result: Dict[str, Any], streaming_result: D
     streaming_issues = streaming_result.get("overall_summary", {}).get("total_issues_found", 0)
 
     if abs(summary_issues - streaming_issues) > 10:
-        insights.append(f"Analysis divergence detected: Summary found {summary_issues} issues, streaming found {streaming_issues}")
+        insights.append(
+            f"Analysis divergence detected: Summary found "
+            f"{summary_issues} issues, streaming found "
+            f"{streaming_issues}"
+        )
 
     # Check for consistency in error patterns
     summary_errors = set(summary_result.get("patterns", {}).get("errors", {}).keys())
-    streaming_errors = set(streaming_result.get("overall_summary", {}).get("most_common_errors", {}).keys())
+    streaming_errors = set(
+        streaming_result.get("overall_summary", {}).get("most_common_errors", {}).keys()
+    )
 
     common_errors = summary_errors.intersection(streaming_errors)
     if common_errors:
-        insights.append(f"Consistent error patterns identified: {', '.join(list(common_errors)[:3])}")
+        insights.append(
+            f"Consistent error patterns identified: {', '.join(list(common_errors)[:3])}"
+        )
 
     combined["combined_insights"] = insights
     return combined
 
-def generate_supplementary_insights(primary_results: Dict[str, Any], context: LogAnalysisContext) -> Dict[str, Any]:
+
+def generate_supplementary_insights(
+    primary_results: Dict[str, Any], context: LogAnalysisContext
+) -> Dict[str, Any]:
     """Generate supplementary insights based on context."""
 
-    insights = {
-        "contextual_analysis": [],
-        "recommendations": [],
-        "follow_up_actions": []
-    }
+    insights = {"contextual_analysis": [], "recommendations": [], "follow_up_actions": []}
 
     # Context-specific insights
     if context.request_type == "troubleshooting":
-        insights["contextual_analysis"].append("Analysis focused on troubleshooting - prioritizing error patterns")
+        insights["contextual_analysis"].append(
+            "Analysis focused on troubleshooting - prioritizing error patterns"
+        )
 
         error_count = len(primary_results.get("patterns", {}).get("errors", []))
         if error_count > 5:
-            insights["recommendations"].append("Multiple error patterns found - recommend systematic investigation")
+            insights["recommendations"].append(
+                "Multiple error patterns found - recommend systematic investigation"
+            )
 
     elif context.request_type == "monitoring":
-        insights["contextual_analysis"].append("Monitoring mode - tracking trends and performance indicators")
+        insights["contextual_analysis"].append(
+            "Monitoring mode - tracking trends and performance indicators"
+        )
 
         # Check for performance patterns
         perf_issues = len(primary_results.get("patterns", {}).get("performance", []))
         if perf_issues > 0:
-            insights["recommendations"].append("Performance issues detected - consider resource optimization")
+            insights["recommendations"].append(
+                "Performance issues detected - consider resource optimization"
+            )
 
     # Urgency-based recommendations
     if context.urgency == "critical":
-        insights["follow_up_actions"].append("CRITICAL: Immediate escalation and remediation required")
+        insights["follow_up_actions"].append(
+            "CRITICAL: Immediate escalation and remediation required"
+        )
     elif context.urgency == "high":
         insights["follow_up_actions"].append("HIGH: Schedule investigation within 2 hours")
 
     return insights
 
-def generate_hybrid_recommendations(primary_results: Dict[str, Any], context: LogAnalysisContext, strategy: LogAnalysisStrategy) -> List[str]:
+
+def generate_hybrid_recommendations(
+    primary_results: Dict[str, Any], context: LogAnalysisContext, strategy: LogAnalysisStrategy
+) -> List[str]:
     """Generate recommendations based on hybrid analysis."""
 
     recommendations = []
@@ -715,7 +829,9 @@ def generate_hybrid_recommendations(primary_results: Dict[str, Any], context: Lo
     total_issues = primary_results.get("summary", {}).get("total_issues", 0)
 
     if context.urgency == "critical" and total_issues > 10:
-        recommendations.append("IMMEDIATE ACTION: High issue count in critical context - activate incident response")
+        recommendations.append(
+            "IMMEDIATE ACTION: High issue count in critical context - activate incident response"
+        )
 
     if context.follow_up_analysis:
         recommendations.append("Follow-up analysis recommended - schedule detailed investigation")
@@ -724,19 +840,25 @@ def generate_hybrid_recommendations(primary_results: Dict[str, Any], context: Lo
     patterns = primary_results.get("patterns", {})
 
     if "memory_issues" in patterns and len(patterns["memory_issues"]) > 3:
-        recommendations.append("Memory issues detected - review resource limits and check for leaks")
+        recommendations.append(
+            "Memory issues detected - review resource limits and check for leaks"
+        )
 
     if "network_issues" in patterns and len(patterns["network_issues"]) > 2:
-        recommendations.append("Network connectivity issues - verify service mesh and DNS configuration")
+        recommendations.append(
+            "Network connectivity issues - verify service mesh and DNS configuration"
+        )
 
     return recommendations
+
 
 # Create global cache instance
 analysis_cache = AnalysisCache(max_size=50)
 
-def generate_focused_summary(patterns: Dict[str, List[Dict[str, Any]]],
-                            focus_areas: List[str],
-                            summary_level: str) -> Dict[str, Any]:
+
+def generate_focused_summary(
+    patterns: Dict[str, List[Dict[str, Any]]], focus_areas: List[str], summary_level: str
+) -> Dict[str, Any]:
     """Generate a focused summary based on extracted patterns."""
     summary = {
         "overview": {},
@@ -744,7 +866,7 @@ def generate_focused_summary(patterns: Dict[str, List[Dict[str, Any]]],
         "recommendations": [],
         "pattern_counts": {},
         "timeline_analysis": {},
-        "critical_issues": []
+        "critical_issues": [],
     }
 
     # Count patterns
@@ -761,7 +883,7 @@ def generate_focused_summary(patterns: Dict[str, List[Dict[str, Any]]],
         "error_count": error_count,
         "warning_count": warning_count,
         "performance_issues": len(patterns.get("performance", [])),
-        "critical_categories": [cat for cat, items in patterns.items() if len(items) > 5]
+        "critical_categories": [cat for cat, items in patterns.items() if len(items) > 5],
     }
 
     # Key findings based on summary level
@@ -771,11 +893,13 @@ def generate_focused_summary(patterns: Dict[str, List[Dict[str, Any]]],
             if category in patterns and patterns[category]:
                 # Get most frequent error patterns
                 error_messages = [item["content"] for item in patterns[category][:10]]
-                summary["key_findings"].append({
-                    "category": category,
-                    "count": len(patterns[category]),
-                    "sample_messages": error_messages[:5]
-                })
+                summary["key_findings"].append(
+                    {
+                        "category": category,
+                        "count": len(patterns[category]),
+                        "sample_messages": error_messages[:5],
+                    }
+                )
 
     # Timeline analysis for comprehensive summaries
     if summary_level == "comprehensive":
@@ -783,11 +907,13 @@ def generate_focused_summary(patterns: Dict[str, List[Dict[str, Any]]],
         for category, items in patterns.items():
             for item in items:
                 if item.get("timestamp"):
-                    timestamps.append({
-                        "timestamp": item["timestamp"],
-                        "category": category,
-                        "line": item["line_number"]
-                    })
+                    timestamps.append(
+                        {
+                            "timestamp": item["timestamp"],
+                            "category": category,
+                            "line": item["line_number"],
+                        }
+                    )
 
         if timestamps:
             # Sort by timestamp (simplified)
@@ -795,7 +921,7 @@ def generate_focused_summary(patterns: Dict[str, List[Dict[str, Any]]],
             summary["timeline_analysis"] = {
                 "first_issue": timestamps[0] if timestamps else None,
                 "last_issue": timestamps[-1] if timestamps else None,
-                "issue_distribution": {}
+                "issue_distribution": {},
             }
 
     # Critical issues (high-priority items)
@@ -806,17 +932,29 @@ def generate_focused_summary(patterns: Dict[str, List[Dict[str, Any]]],
 
     # Recommendations
     if error_count > 10:
-        summary["recommendations"].append("High error count detected. Investigate application stability.")
+        summary["recommendations"].append(
+            "High error count detected. Investigate application stability."
+        )
     if len(patterns.get("memory_issues", [])) > 0:
-        summary["recommendations"].append("Memory issues detected. Consider increasing pod memory limits or investigating memory leaks.")
+        summary["recommendations"].append(
+            "Memory issues detected. Consider increasing pod "
+            "memory limits or investigating memory leaks."
+        )
     if len(patterns.get("timeouts", [])) > 5:
-        summary["recommendations"].append("Multiple timeout issues found. Check network connectivity and service dependencies.")
+        summary["recommendations"].append(
+            "Multiple timeout issues found. Check network connectivity and service dependencies."
+        )
     if len(patterns.get("performance", [])) > 5:
-        summary["recommendations"].append("Performance issues detected. Consider resource optimization or scaling.")
+        summary["recommendations"].append(
+            "Performance issues detected. Consider resource optimization or scaling."
+        )
 
     return summary
 
-def get_strategy_selection_reason(context: LogAnalysisContext, strategy: LogAnalysisStrategy) -> str:
+
+def get_strategy_selection_reason(
+    context: LogAnalysisContext, strategy: LogAnalysisStrategy
+) -> str:
     """Get explanation for why a strategy was selected."""
     if strategy == LogAnalysisStrategy.STREAMING:
         if context.urgency == "critical":
@@ -830,7 +968,11 @@ def get_strategy_selection_reason(context: LogAnalysisContext, strategy: LogAnal
         if context.log_size_estimate > 50000:
             return "Smart summary selected for large log size requiring efficient processing"
         elif context.request_type in ["investigation", "monitoring"]:
-            return f"Smart summary selected for {context.request_type} requiring comprehensive analysis"
+            return (
+                f"Smart summary selected for "
+                f"{context.request_type} requiring "
+                "comprehensive analysis"
+            )
         else:
             return "Smart summary selected as versatile default strategy"
 
@@ -840,36 +982,42 @@ def get_strategy_selection_reason(context: LogAnalysisContext, strategy: LogAnal
     else:
         return "Strategy selected based on automatic optimization"
 
+
 def preprocess_log_data(log_lines: List[str]) -> pd.DataFrame:
     """Preprocess log data for ML analysis."""
     processed_data = []
 
     for line in log_lines:
         # Extract timestamp if present
-        timestamp_match = re.search(r'\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}', line)
+        timestamp_match = re.search(r"\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}", line)
         timestamp = timestamp_match.group() if timestamp_match else None
 
         # Extract log level
-        level_match = re.search(r'\b(DEBUG|INFO|WARN|ERROR|FATAL|PANIC)\b', line, re.IGNORECASE)
-        log_level = level_match.group().upper() if level_match else 'UNKNOWN'
+        level_match = re.search(r"\b(DEBUG|INFO|WARN|ERROR|FATAL|PANIC)\b", line, re.IGNORECASE)
+        log_level = level_match.group().upper() if level_match else "UNKNOWN"
 
         # Extract error patterns
-        error_indicators = len(re.findall(r'\b(error|exception|failed|fatal|panic|timeout)\b', line, re.IGNORECASE))
+        error_indicators = len(
+            re.findall(r"\b(error|exception|failed|fatal|panic|timeout)\b", line, re.IGNORECASE)
+        )
 
         # Calculate message length and entropy
         message_length = len(line)
         message_entropy = calculate_entropy(line)
 
-        processed_data.append({
-            'timestamp': timestamp,
-            'log_level': log_level,
-            'error_indicators': error_indicators,
-            'message_length': message_length,
-            'message_entropy': message_entropy,
-            'raw_message': line
-        })
+        processed_data.append(
+            {
+                "timestamp": timestamp,
+                "log_level": log_level,
+                "error_indicators": error_indicators,
+                "message_length": message_length,
+                "message_entropy": message_entropy,
+                "raw_message": line,
+            }
+        )
 
     return pd.DataFrame(processed_data)
+
 
 def calculate_entropy(text: str) -> float:
     """Calculate Shannon entropy of text."""
@@ -891,49 +1039,61 @@ def calculate_entropy(text: str) -> float:
 
     return entropy
 
+
 def extract_log_features(df: pd.DataFrame) -> np.ndarray:
     """Extract features from preprocessed log data."""
-    features = []
 
     # Time-based features
-    df['hour'] = pd.to_datetime(df['timestamp'], errors='coerce').dt.hour
-    df['minute'] = pd.to_datetime(df['timestamp'], errors='coerce').dt.minute
+    df["hour"] = pd.to_datetime(df["timestamp"], errors="coerce").dt.hour
+    df["minute"] = pd.to_datetime(df["timestamp"], errors="coerce").dt.minute
 
     # Rolling window features (last 10 messages)
     window_size = 10
-    df['error_rate_window'] = df['error_indicators'].rolling(window=window_size, min_periods=1).mean()
-    df['avg_length_window'] = df['message_length'].rolling(window=window_size, min_periods=1).mean()
-    df['entropy_trend'] = df['message_entropy'].rolling(window=window_size, min_periods=1).std()
+    df["error_rate_window"] = (
+        df["error_indicators"].rolling(window=window_size, min_periods=1).mean()
+    )
+    df["avg_length_window"] = df["message_length"].rolling(window=window_size, min_periods=1).mean()
+    df["entropy_trend"] = df["message_entropy"].rolling(window=window_size, min_periods=1).std()
 
     # Log level encoding
-    level_encoding = {'DEBUG': 0, 'INFO': 1, 'WARN': 2, 'ERROR': 3, 'FATAL': 4, 'PANIC': 5, 'UNKNOWN': 0}
-    df['log_level_encoded'] = df['log_level'].map(level_encoding)
+    level_encoding = {
+        "DEBUG": 0,
+        "INFO": 1,
+        "WARN": 2,
+        "ERROR": 3,
+        "FATAL": 4,
+        "PANIC": 5,
+        "UNKNOWN": 0,
+    }
+    df["log_level_encoded"] = df["log_level"].map(level_encoding)
 
     # Select feature columns
     feature_columns = [
-        'error_indicators', 'message_length', 'message_entropy',
-        'hour', 'minute', 'error_rate_window', 'avg_length_window',
-        'entropy_trend', 'log_level_encoded'
+        "error_indicators",
+        "message_length",
+        "message_entropy",
+        "hour",
+        "minute",
+        "error_rate_window",
+        "avg_length_window",
+        "entropy_trend",
+        "log_level_encoded",
     ]
 
     return df[feature_columns].fillna(0).values
 
+
 def train_anomaly_model(features: np.ndarray, contamination: float = 0.1):
     """Train isolation forest model for anomaly detection."""
     from sklearn.ensemble import IsolationForest
-    model = IsolationForest(
-        contamination=contamination,
-        random_state=42,
-        n_estimators=100
-    )
+
+    model = IsolationForest(contamination=contamination, random_state=42, n_estimators=100)
     model.fit(features)
     return model
 
 
 def train_enhanced_anomaly_model(
-    features: np.ndarray,
-    labels: Optional[np.ndarray] = None,
-    contamination: float = 0.1
+    features: np.ndarray, labels: Optional[np.ndarray] = None, contamination: float = 0.1
 ):
     """Train anomaly model with optional label guidance (semi-supervised).
 
@@ -958,8 +1118,8 @@ def train_enhanced_anomaly_model(
         contamination=contamination,
         random_state=42,
         n_estimators=100,
-        max_samples='auto',
-        bootstrap=True
+        max_samples="auto",
+        bootstrap=True,
     )
 
     model.fit(features)
@@ -971,7 +1131,7 @@ def train_or_load_model(
     model_manager,
     version_manager,
     labels: Optional[np.ndarray] = None,
-    force_retrain: bool = False
+    force_retrain: bool = False,
 ) -> Tuple[Any, str, Dict[str, Any]]:
     """Load existing model or train new one based on conditions.
 
@@ -1023,13 +1183,9 @@ def train_or_load_model(
         "performance_metrics": {
             "accuracy": float(normal_rate),
             "precision": float(max(0.7, normal_rate - 0.1)),
-            "recall": float(max(0.6, normal_rate - 0.2))
+            "recall": float(max(0.6, normal_rate - 0.2)),
         },
-        "training_config": {
-            "contamination": 0.1,
-            "n_estimators": 100,
-            "random_state": 42
-        }
+        "training_config": {"contamination": 0.1, "n_estimators": 100, "random_state": 42},
     }
 
     # Save model to disk
@@ -1041,7 +1197,9 @@ def train_or_load_model(
     return model, new_model_id, metadata
 
 
-def analyze_log_patterns_for_failure_prediction(log_data: pd.DataFrame, historical_failures: List[Dict]) -> Dict[str, Any]:
+def analyze_log_patterns_for_failure_prediction(
+    log_data: pd.DataFrame, historical_failures: List[Dict]
+) -> Dict[str, Any]:
     """Analyze log patterns to predict potential failures.
 
     Args:
@@ -1053,72 +1211,80 @@ def analyze_log_patterns_for_failure_prediction(log_data: pd.DataFrame, historic
     """
     failure_patterns = []
     historical_context = {
-        'total_historical_failures': len(historical_failures),
-        'failure_types_seen': {},
-        'recent_failures': []
+        "total_historical_failures": len(historical_failures),
+        "failure_types_seen": {},
+        "recent_failures": [],
     }
 
     # Pattern 1: High error rate
-    error_rate = log_data['error_indicators'].mean() if 'error_indicators' in log_data.columns else 0
+    error_rate = (
+        log_data["error_indicators"].mean() if "error_indicators" in log_data.columns else 0
+    )
     if error_rate > 0.1:  # More than 10% error indicators
-        failure_patterns.append({
-            'pattern': 'high_error_rate',
-            'severity': 'high' if error_rate > 0.3 else 'medium',
-            'value': error_rate
-        })
+        failure_patterns.append(
+            {
+                "pattern": "high_error_rate",
+                "severity": "high" if error_rate > 0.3 else "medium",
+                "value": error_rate,
+            }
+        )
 
     # Pattern 2: Entropy spikes (indicating unusual log patterns)
-    if 'message_entropy' in log_data.columns and len(log_data) > 0:
-        entropy_mean = log_data['message_entropy'].mean()
-        entropy_std = log_data['message_entropy'].std()
+    if "message_entropy" in log_data.columns and len(log_data) > 0:
+        entropy_mean = log_data["message_entropy"].mean()
+        entropy_std = log_data["message_entropy"].std()
         if entropy_std > 0:
             entropy_threshold = entropy_mean + 2 * entropy_std
-            entropy_spikes = (log_data['message_entropy'] > entropy_threshold).sum()
+            entropy_spikes = (log_data["message_entropy"] > entropy_threshold).sum()
             if entropy_spikes > len(log_data) * 0.05:
-                failure_patterns.append({
-                    'pattern': 'entropy_spikes',
-                    'severity': 'medium',
-                    'value': entropy_spikes / len(log_data)
-                })
+                failure_patterns.append(
+                    {
+                        "pattern": "entropy_spikes",
+                        "severity": "medium",
+                        "value": entropy_spikes / len(log_data),
+                    }
+                )
 
     # Pattern 3: Message length anomalies
-    if 'message_length' in log_data.columns and len(log_data) > 0:
-        length_mean = log_data['message_length'].mean()
-        length_std = log_data['message_length'].std()
+    if "message_length" in log_data.columns and len(log_data) > 0:
+        length_mean = log_data["message_length"].mean()
+        length_std = log_data["message_length"].std()
         if length_std > 0:
             length_threshold = length_mean + 3 * length_std
-            length_anomalies = (log_data['message_length'] > length_threshold).sum()
+            length_anomalies = (log_data["message_length"] > length_threshold).sum()
             if length_anomalies > 0:
-                failure_patterns.append({
-                    'pattern': 'message_length_anomalies',
-                    'severity': 'low',
-                    'value': length_anomalies
-                })
+                failure_patterns.append(
+                    {
+                        "pattern": "message_length_anomalies",
+                        "severity": "low",
+                        "value": length_anomalies,
+                    }
+                )
 
     # Pattern 4: Analyze historical failures for predictive patterns
     if historical_failures:
         # Count failure types
         failure_type_counts = {}
-        severity_counts = {'critical': 0, 'high': 0, 'medium': 0, 'low': 0}
+        severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
 
         for failure in historical_failures:
-            ftype = failure.get('failure_type', 'unknown')
-            severity = failure.get('severity', 'medium')
+            ftype = failure.get("failure_type", "unknown")
+            severity = failure.get("severity", "medium")
 
             failure_type_counts[ftype] = failure_type_counts.get(ftype, 0) + 1
             if severity in severity_counts:
                 severity_counts[severity] += 1
 
-        historical_context['failure_types_seen'] = failure_type_counts
-        historical_context['severity_distribution'] = severity_counts
+        historical_context["failure_types_seen"] = failure_type_counts
+        historical_context["severity_distribution"] = severity_counts
 
         # Add recent failures to context (last 5)
-        historical_context['recent_failures'] = [
+        historical_context["recent_failures"] = [
             {
-                'failure_type': f.get('failure_type'),
-                'severity': f.get('severity'),
-                'resource_name': f.get('resource_name'),
-                'failure_time': f.get('failure_time')
+                "failure_type": f.get("failure_type"),
+                "severity": f.get("severity"),
+                "resource_name": f.get("resource_name"),
+                "failure_time": f.get("failure_time"),
             }
             for f in historical_failures[:5]
         ]
@@ -1126,38 +1292,47 @@ def analyze_log_patterns_for_failure_prediction(log_data: pd.DataFrame, historic
         # Pattern: Recurring failure types indicate elevated risk
         for ftype, count in failure_type_counts.items():
             if count >= 2:  # Same failure type occurred 2+ times
-                failure_patterns.append({
-                    'pattern': 'recurring_failure',
-                    'severity': 'high',
-                    'value': count,
-                    'failure_type': ftype,
-                    'description': f"'{ftype}' failure occurred {count} times in last 24h"
-                })
+                failure_patterns.append(
+                    {
+                        "pattern": "recurring_failure",
+                        "severity": "high",
+                        "value": count,
+                        "failure_type": ftype,
+                        "description": f"'{ftype}' failure occurred {count} times in last 24h",
+                    }
+                )
 
         # Pattern: Critical/high severity failures in recent history
-        critical_high = severity_counts['critical'] + severity_counts['high']
+        critical_high = severity_counts["critical"] + severity_counts["high"]
         if critical_high > 0:
-            failure_patterns.append({
-                'pattern': 'recent_critical_failures',
-                'severity': 'high' if severity_counts['critical'] > 0 else 'medium',
-                'value': critical_high,
-                'description': f"{critical_high} critical/high severity failures in last 24h"
-            })
+            failure_patterns.append(
+                {
+                    "pattern": "recent_critical_failures",
+                    "severity": "high" if severity_counts["critical"] > 0 else "medium",
+                    "value": critical_high,
+                    "description": f"{critical_high} critical/high severity failures in last 24h",
+                }
+            )
 
         # Pattern: High failure density (many failures in short time)
         if len(historical_failures) >= 5:
-            failure_patterns.append({
-                'pattern': 'high_failure_density',
-                'severity': 'high',
-                'value': len(historical_failures),
-                'description': f"{len(historical_failures)} failures in last 24h indicates instability"
-            })
+            failure_patterns.append(
+                {
+                    "pattern": "high_failure_density",
+                    "severity": "high",
+                    "value": len(historical_failures),
+                    "description": (
+                        f"{len(historical_failures)} failures "
+                        "in last 24h indicates instability"
+                    ),
+                }
+            )
 
     # Calculate risk score with historical failure weighting
     base_risk = (
-        sum(1 for p in failure_patterns if p['severity'] == 'high') * 0.5 +
-        sum(1 for p in failure_patterns if p['severity'] == 'medium') * 0.3 +
-        sum(1 for p in failure_patterns if p['severity'] == 'low') * 0.1
+        sum(1 for p in failure_patterns if p["severity"] == "high") * 0.5
+        + sum(1 for p in failure_patterns if p["severity"] == "medium") * 0.3
+        + sum(1 for p in failure_patterns if p["severity"] == "low") * 0.1
     )
 
     # Boost risk score based on historical failure count (up to 0.5 additional)
@@ -1167,17 +1342,18 @@ def analyze_log_patterns_for_failure_prediction(log_data: pd.DataFrame, historic
     risk_score = min(base_risk + historical_boost, 2.0)
 
     return {
-        'failure_patterns': failure_patterns,
-        'risk_score': risk_score,
-        'historical_context': historical_context
+        "failure_patterns": failure_patterns,
+        "risk_score": risk_score,
+        "historical_context": historical_context,
     }
+
 
 def generate_failure_predictions(
     patterns: Dict[str, Any],
     confidence_threshold: float,
     prediction_window: str,
     historical_failures: Optional[List[Dict]] = None,
-    labels: Optional[Any] = None
+    labels: Optional[Any] = None,
 ) -> List[Dict[str, Any]]:
     """Generate failure predictions based on detected patterns and historical data.
 
@@ -1194,9 +1370,9 @@ def generate_failure_predictions(
     predictions = []
     historical_failures = historical_failures or []
 
-    risk_score = patterns.get('risk_score', 0)
-    failure_patterns = patterns.get('failure_patterns', [])
-    historical_context = patterns.get('historical_context', {})
+    risk_score = patterns.get("risk_score", 0)
+    failure_patterns = patterns.get("failure_patterns", [])
+    historical_context = patterns.get("historical_context", {})
 
     # Calculate base confidence from risk score
     base_confidence = min(risk_score * 0.6, 0.95)
@@ -1206,6 +1382,7 @@ def generate_failure_predictions(
     if labels is not None:
         try:
             import numpy as np
+
             if isinstance(labels, np.ndarray) and len(labels) > 0:
                 # Percentage of logs correlated with failures
                 failure_correlation_rate = np.mean(labels)
@@ -1224,9 +1401,7 @@ def generate_failure_predictions(
     confidence = min(base_confidence + label_boost + historical_boost, 0.95)
 
     # Calculate predicted time based on window
-    window_hours = {
-        "1h": 1, "6h": 6, "24h": 24, "7d": 168
-    }.get(prediction_window, 6)
+    window_hours = {"1h": 1, "6h": 6, "24h": 24, "7d": 168}.get(prediction_window, 6)
 
     predicted_time = (datetime.now() + timedelta(hours=window_hours)).isoformat()
 
@@ -1238,59 +1413,69 @@ def generate_failure_predictions(
         recommended_actions = []
 
         for pattern in failure_patterns:
-            pattern_type = pattern.get('pattern', '')
+            pattern_type = pattern.get("pattern", "")
 
-            if pattern_type == 'high_error_rate':
-                failure_types.append('service_degradation')
-                affected_components.append('application_pods')
+            if pattern_type == "high_error_rate":
+                failure_types.append("service_degradation")
+                affected_components.append("application_pods")
                 warning_indicators.append(f"Error rate at {pattern['value']:.2%}")
                 recommended_actions.append("Investigate error logs and increase monitoring")
 
-            elif pattern_type == 'entropy_spikes':
-                failure_types.append('unusual_behavior')
-                affected_components.append('logging_system')
+            elif pattern_type == "entropy_spikes":
+                failure_types.append("unusual_behavior")
+                affected_components.append("logging_system")
                 warning_indicators.append(f"Entropy spikes in {pattern['value']:.2%} of logs")
                 recommended_actions.append("Check for configuration changes or new deployments")
 
-            elif pattern_type == 'recurring_failure':
-                ftype = pattern.get('failure_type', 'unknown')
+            elif pattern_type == "recurring_failure":
+                ftype = pattern.get("failure_type", "unknown")
                 failure_types.append(ftype)
-                affected_components.append(pattern.get('resource_type', 'unknown'))
-                warning_indicators.append(pattern.get('description', f"Recurring {ftype} failures"))
-                recommended_actions.append(f"Investigate root cause of recurring '{ftype}' failures")
+                affected_components.append(pattern.get("resource_type", "unknown"))
+                warning_indicators.append(pattern.get("description", f"Recurring {ftype} failures"))
+                recommended_actions.append(
+                    f"Investigate root cause of recurring '{ftype}' failures"
+                )
 
-            elif pattern_type == 'recent_critical_failures':
-                failure_types.append('critical_failure_risk')
-                affected_components.append('cluster')
-                warning_indicators.append(pattern.get('description', 'Recent critical failures detected'))
-                recommended_actions.append("Review recent critical failures and ensure fixes are in place")
+            elif pattern_type == "recent_critical_failures":
+                failure_types.append("critical_failure_risk")
+                affected_components.append("cluster")
+                warning_indicators.append(
+                    pattern.get("description", "Recent critical failures detected")
+                )
+                recommended_actions.append(
+                    "Review recent critical failures and ensure fixes are in place"
+                )
 
-            elif pattern_type == 'high_failure_density':
-                failure_types.append('system_instability')
-                affected_components.append('cluster')
-                warning_indicators.append(pattern.get('description', 'High failure density detected'))
+            elif pattern_type == "high_failure_density":
+                failure_types.append("system_instability")
+                affected_components.append("cluster")
+                warning_indicators.append(
+                    pattern.get("description", "High failure density detected")
+                )
                 recommended_actions.append("Perform comprehensive system health check")
 
         # Create prediction entry
         if failure_types:
-            predictions.append({
-                'failure_type': failure_types[0],
-                'all_failure_types': list(set(failure_types)),
-                'predicted_time': predicted_time,
-                'confidence': round(confidence, 3),
-                'affected_components': list(set(affected_components)),
-                'warning_indicators': warning_indicators,
-                'recommended_actions': list(set(recommended_actions)),
-                'based_on_patterns': len(failure_patterns),
-                'based_on_historical_failures': len(historical_failures),
-                'has_labeled_correlations': labels is not None and label_boost > 0
-            })
+            predictions.append(
+                {
+                    "failure_type": failure_types[0],
+                    "all_failure_types": list(set(failure_types)),
+                    "predicted_time": predicted_time,
+                    "confidence": round(confidence, 3),
+                    "affected_components": list(set(affected_components)),
+                    "warning_indicators": warning_indicators,
+                    "recommended_actions": list(set(recommended_actions)),
+                    "based_on_patterns": len(failure_patterns),
+                    "based_on_historical_failures": len(historical_failures),
+                    "has_labeled_correlations": labels is not None and label_boost > 0,
+                }
+            )
 
     # Also generate predictions directly from historical failures if no pattern-based predictions
     # and we have enough historical data
     if not predictions and historical_failures and len(historical_failures) >= 3:
         # Find the most common failure type
-        failure_type_counts = historical_context.get('failure_types_seen', {})
+        failure_type_counts = historical_context.get("failure_types_seen", {})
         if failure_type_counts:
             most_common = max(failure_type_counts.items(), key=lambda x: x[1])
             ftype, count = most_common
@@ -1299,42 +1484,40 @@ def generate_failure_predictions(
             historical_confidence = min(0.5 + (count * 0.1), 0.85)
 
             if historical_confidence >= confidence_threshold:
-                predictions.append({
-                    'failure_type': ftype,
-                    'predicted_time': predicted_time,
-                    'confidence': round(historical_confidence, 3),
-                    'affected_components': ['cluster'],
-                    'warning_indicators': [
-                        f"'{ftype}' failure occurred {count} times recently",
-                        f"Based on {len(historical_failures)} historical failures"
-                    ],
-                    'recommended_actions': [
-                        f"Proactively address '{ftype}' failure patterns",
-                        "Review recent changes that may have introduced instability"
-                    ],
-                    'prediction_source': 'historical_pattern',
-                    'based_on_historical_failures': len(historical_failures)
-                })
+                predictions.append(
+                    {
+                        "failure_type": ftype,
+                        "predicted_time": predicted_time,
+                        "confidence": round(historical_confidence, 3),
+                        "affected_components": ["cluster"],
+                        "warning_indicators": [
+                            f"'{ftype}' failure occurred {count} times recently",
+                            f"Based on {len(historical_failures)} historical failures",
+                        ],
+                        "recommended_actions": [
+                            f"Proactively address '{ftype}' failure patterns",
+                            "Review recent changes that may have introduced instability",
+                        ],
+                        "prediction_source": "historical_pattern",
+                        "based_on_historical_failures": len(historical_failures),
+                    }
+                )
 
     return predictions
 
+
 def _build_log_params(search_params: Dict[str, Any]) -> Dict[str, Any]:
     """Build log retrieval parameters from search params."""
-    time_range = search_params.get('time_range', '1h')
+    time_range = search_params.get("time_range", "1h")
 
     # Convert time range to seconds
-    time_mapping = {
-        '1h': 3600,
-        '6h': 21600,
-        '24h': 86400,
-        '7d': 604800
-    }
+    time_mapping = {"1h": 3600, "6h": 21600, "24h": 86400, "7d": 604800}
 
     since_seconds = time_mapping.get(time_range, 3600)
 
     return {
-        'since_seconds': since_seconds,
-        'tail_lines': 500  # Reasonable limit for semantic analysis
+        "since_seconds": since_seconds,
+        "tail_lines": 500,  # Reasonable limit for semantic analysis
     }
 
 
@@ -1342,7 +1525,10 @@ def _build_log_params(search_params: Dict[str, Any]) -> Dict[str, Any]:
 # TOKEN LIMIT TRUNCATION FUNCTIONS
 # ============================================================================
 
-def truncate_to_token_limit(data: Dict[str, Any], max_tokens: int, chars_per_token: int = 4) -> Dict[str, Any]:
+
+def truncate_to_token_limit(
+    data: Dict[str, Any], max_tokens: int, chars_per_token: int = 4
+) -> Dict[str, Any]:
     """Truncate response data to fit within token limit.
 
     Args:
@@ -1370,15 +1556,19 @@ def truncate_to_token_limit(data: Dict[str, Any], max_tokens: int, chars_per_tok
 
     # Progressive truncation strategy
     # Stage 1: Truncate patterns to top N per category
-    if 'patterns' in result and isinstance(result['patterns'], dict):
+    if "patterns" in result and isinstance(result["patterns"], dict):
         max_per_category = max(5, max_tokens // 200)  # Scale with token limit
-        for category in result['patterns']:
-            if isinstance(result['patterns'][category], list):
-                result['patterns'][category] = result['patterns'][category][:max_per_category]
+        for category in result["patterns"]:
+            if isinstance(result["patterns"][category], list):
+                result["patterns"][category] = result["patterns"][category][:max_per_category]
                 # Also truncate content within each pattern
-                for pattern in result['patterns'][category]:
-                    if isinstance(pattern, dict) and 'content' in pattern:
-                        pattern['content'] = pattern['content'][:150] + "..." if len(pattern.get('content', '')) > 150 else pattern.get('content', '')
+                for pattern in result["patterns"][category]:
+                    if isinstance(pattern, dict) and "content" in pattern:
+                        pattern["content"] = (
+                            pattern["content"][:150] + "..."
+                            if len(pattern.get("content", "")) > 150
+                            else pattern.get("content", "")
+                        )
 
     # Check size after stage 1
     try:
@@ -1387,17 +1577,16 @@ def truncate_to_token_limit(data: Dict[str, Any], max_tokens: int, chars_per_tok
         pass
 
     if current_tokens <= max_tokens:
-        result['_truncated'] = True
-        result['_truncation_stage'] = 1
+        result["_truncated"] = True
+        result["_truncation_stage"] = 1
         return result
 
     # Stage 2: Convert time_segments to counts only
-    if 'time_segments' in result and isinstance(result['time_segments'], dict):
-        result['time_segments'] = {
-            k: len(v) if isinstance(v, list) else v
-            for k, v in result['time_segments'].items()
+    if "time_segments" in result and isinstance(result["time_segments"], dict):
+        result["time_segments"] = {
+            k: len(v) if isinstance(v, list) else v for k, v in result["time_segments"].items()
         }
-        result['time_segments']['_note'] = 'Counts only - full logs truncated for token limit'
+        result["time_segments"]["_note"] = "Counts only - full logs truncated for token limit"
 
     # Check size after stage 2
     try:
@@ -1406,17 +1595,21 @@ def truncate_to_token_limit(data: Dict[str, Any], max_tokens: int, chars_per_tok
         pass
 
     if current_tokens <= max_tokens:
-        result['_truncated'] = True
-        result['_truncation_stage'] = 2
+        result["_truncated"] = True
+        result["_truncation_stage"] = 2
         return result
 
     # Stage 3: Truncate representative_samples
-    if 'representative_samples' in result and isinstance(result['representative_samples'], list):
+    if "representative_samples" in result and isinstance(result["representative_samples"], list):
         max_samples = max(3, max_tokens // 500)
-        result['representative_samples'] = result['representative_samples'][:max_samples]
-        for sample in result['representative_samples']:
-            if isinstance(sample, dict) and 'content' in sample:
-                sample['content'] = sample['content'][:100] + "..." if len(sample.get('content', '')) > 100 else sample.get('content', '')
+        result["representative_samples"] = result["representative_samples"][:max_samples]
+        for sample in result["representative_samples"]:
+            if isinstance(sample, dict) and "content" in sample:
+                sample["content"] = (
+                    sample["content"][:100] + "..."
+                    if len(sample.get("content", "")) > 100
+                    else sample.get("content", "")
+                )
 
     # Check size after stage 3
     try:
@@ -1425,20 +1618,20 @@ def truncate_to_token_limit(data: Dict[str, Any], max_tokens: int, chars_per_tok
         pass
 
     if current_tokens <= max_tokens:
-        result['_truncated'] = True
-        result['_truncation_stage'] = 3
+        result["_truncated"] = True
+        result["_truncation_stage"] = 3
         return result
 
     # Stage 4: Truncate chunk results (for streaming analysis)
-    if 'chunks' in result and isinstance(result['chunks'], list):
+    if "chunks" in result and isinstance(result["chunks"], list):
         max_chunks = max(3, max_tokens // 1000)
-        result['chunks'] = result['chunks'][:max_chunks]
+        result["chunks"] = result["chunks"][:max_chunks]
         # Truncate patterns within each chunk
-        for chunk in result['chunks']:
-            if isinstance(chunk, dict) and 'patterns' in chunk:
-                for category in chunk['patterns']:
-                    if isinstance(chunk['patterns'][category], list):
-                        chunk['patterns'][category] = chunk['patterns'][category][:5]
+        for chunk in result["chunks"]:
+            if isinstance(chunk, dict) and "patterns" in chunk:
+                for category in chunk["patterns"]:
+                    if isinstance(chunk["patterns"][category], list):
+                        chunk["patterns"][category] = chunk["patterns"][category][:5]
 
     # Stage 5: Remove large metadata fields if still too large
     try:
@@ -1448,20 +1641,22 @@ def truncate_to_token_limit(data: Dict[str, Any], max_tokens: int, chars_per_tok
 
     if current_tokens > max_tokens:
         # Remove optional large fields
-        fields_to_trim = ['raw_logs', 'full_timeline', 'detailed_analysis', 'chunk_details']
+        fields_to_trim = ["raw_logs", "full_timeline", "detailed_analysis", "chunk_details"]
         for field in fields_to_trim:
             if field in result:
                 del result[field]
 
-    result['_truncated'] = True
-    result['_truncation_stage'] = 'final'
-    result['_original_token_estimate'] = current_tokens
-    result['_max_tokens'] = max_tokens
+    result["_truncated"] = True
+    result["_truncation_stage"] = "final"
+    result["_original_token_estimate"] = current_tokens
+    result["_max_tokens"] = max_tokens
 
     return result
 
 
-def truncate_streaming_results(chunk_results: List[Dict[str, Any]], max_tokens: int) -> List[Dict[str, Any]]:
+def truncate_streaming_results(
+    chunk_results: List[Dict[str, Any]], max_tokens: int
+) -> List[Dict[str, Any]]:
     """Truncate streaming chunk results to fit within token limit.
 
     Args:
@@ -1496,12 +1691,12 @@ def truncate_streaming_results(chunk_results: List[Dict[str, Any]], max_tokens: 
 
     # Further truncate patterns within each chunk
     for chunk in truncated:
-        if 'patterns' in chunk and isinstance(chunk['patterns'], dict):
-            for category in chunk['patterns']:
-                if isinstance(chunk['patterns'][category], list):
-                    chunk['patterns'][category] = chunk['patterns'][category][:10]
+        if "patterns" in chunk and isinstance(chunk["patterns"], dict):
+            for category in chunk["patterns"]:
+                if isinstance(chunk["patterns"][category], list):
+                    chunk["patterns"][category] = chunk["patterns"][category][:10]
 
-        if 'new_issues' in chunk and isinstance(chunk['new_issues'], list):
-            chunk['new_issues'] = chunk['new_issues'][:5]
+        if "new_issues" in chunk and isinstance(chunk["new_issues"], list):
+            chunk["new_issues"] = chunk["new_issues"][:5]
 
     return truncated

--- a/src/helpers/resource_topology.py
+++ b/src/helpers/resource_topology.py
@@ -9,7 +9,7 @@
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Dict, List, Any, Optional
 
 logger = logging.getLogger("lumino-mcp")
@@ -19,14 +19,17 @@ logger = logging.getLogger("lumino-mcp")
 # MULTI-CLUSTER CLIENT MANAGEMENT
 # ============================================================================
 
-async def get_multi_cluster_clients(k8s_core_api, k8s_custom_api, k8s_apps_api) -> Dict[str, Dict[str, Any]]:
+
+async def get_multi_cluster_clients(
+    k8s_core_api, k8s_custom_api, k8s_apps_api
+) -> Dict[str, Dict[str, Any]]:
     """Get authenticated clients for multiple clusters."""
     # For now, return the current cluster - extend this for actual multi-cluster setups
     return {
         "current": {
             "core_api": k8s_core_api,
             "custom_api": k8s_custom_api,
-            "apps_api": k8s_apps_api
+            "apps_api": k8s_apps_api,
         }
     }
 
@@ -34,6 +37,7 @@ async def get_multi_cluster_clients(k8s_core_api, k8s_custom_api, k8s_apps_api) 
 # ============================================================================
 # PIPELINE CORRELATION AND TRACKING
 # ============================================================================
+
 
 async def correlate_pipeline_events(
     trace_identifier: str,
@@ -44,7 +48,7 @@ async def correlate_pipeline_events(
     namespaces: Optional[List[str]] = None,
     max_namespaces: int = 50,
     tekton_namespaces: Optional[List[str]] = None,
-    logger=None
+    logger=None,
 ) -> List[Dict[str, Any]]:
     """
     Correlate pipeline runs across clusters using labels, annotations, and artifact references.
@@ -65,7 +69,9 @@ async def correlate_pipeline_events(
     """
     pipeline_flow = []
 
-    async def query_namespace(cluster_name: str, namespace: str, custom_api) -> List[Dict[str, Any]]:
+    async def query_namespace(
+        cluster_name: str, namespace: str, custom_api
+    ) -> List[Dict[str, Any]]:
         """Query PipelineRuns in a single namespace - designed for parallel execution."""
         results = []
         try:
@@ -74,7 +80,7 @@ async def correlate_pipeline_events(
                 version="v1",
                 namespace=namespace,
                 plural="pipelineruns",
-                limit=200
+                limit=200,
             )
 
             for pr in pipeline_runs.get("items", []):
@@ -89,7 +95,7 @@ async def correlate_pipeline_events(
                         "completion_time": pr.get("status", {}).get("completionTime"),
                         "tasks": extract_task_info(pr),
                         "labels": pr.get("metadata", {}).get("labels", {}),
-                        "annotations": pr.get("metadata", {}).get("annotations", {})
+                        "annotations": pr.get("metadata", {}).get("annotations", {}),
                     }
 
                     # Filter by time range if specified
@@ -127,7 +133,15 @@ async def correlate_pipeline_events(
                     else:
                         # No tekton hints - use heuristic prioritization
                         # Prioritize namespaces likely to have pipelines
-                        pipeline_keywords = ['tenant', 'pipeline', 'tekton', 'cicd', 'ci-cd', 'build', 'konflux']
+                        pipeline_keywords = [
+                            "tenant",
+                            "pipeline",
+                            "tekton",
+                            "cicd",
+                            "ci-cd",
+                            "build",
+                            "konflux",
+                        ]
                         prioritized = []
                         others = []
                         for ns in all_namespaces:
@@ -146,7 +160,9 @@ async def correlate_pipeline_events(
                 continue
 
             if logger:
-                logger.info(f"Searching {len(target_namespaces)} namespaces in cluster {cluster_name}")
+                logger.info(
+                    f"Searching {len(target_namespaces)} namespaces in cluster {cluster_name}"
+                )
 
             # Parallelize namespace queries using asyncio.gather
             tasks = [
@@ -173,7 +189,9 @@ async def correlate_pipeline_events(
     return pipeline_flow
 
 
-def matches_trace_identifier(pipeline_run: Dict[str, Any], trace_identifier: str, trace_type: str) -> bool:
+def matches_trace_identifier(
+    pipeline_run: Dict[str, Any], trace_identifier: str, trace_type: str
+) -> bool:
     """Check if a pipeline run matches the trace identifier."""
     metadata = pipeline_run.get("metadata", {})
     labels = metadata.get("labels", {})
@@ -183,27 +201,30 @@ def matches_trace_identifier(pipeline_run: Dict[str, Any], trace_identifier: str
         # Look for commit SHA in labels and annotations
         # Support multiple PAC/Konflux label formats
         commit_keys = [
-            "pipelinesascode.tekton.dev/sha",               # Standard PAC
-            "pac.test.appstudio.openshift.io/sha",           # Konflux/AppStudio PAC
-            "tekton.dev/git-commit",                          # Tekton standard
-            "git.commit",                                     # Generic
-            "build.appstudio.redhat.com/commit_sha",          # Red Hat AppStudio
+            "pipelinesascode.tekton.dev/sha",  # Standard PAC
+            "pac.test.appstudio.openshift.io/sha",  # Konflux/AppStudio PAC
+            "tekton.dev/git-commit",  # Tekton standard
+            "git.commit",  # Generic
+            "build.appstudio.redhat.com/commit_sha",  # Red Hat AppStudio
         ]
         for key in commit_keys:
-            if labels.get(key, "").startswith(trace_identifier) or annotations.get(key, "").startswith(trace_identifier):
+            if labels.get(key, "").startswith(trace_identifier) or annotations.get(
+                key, ""
+            ).startswith(trace_identifier):
                 return True
         # Also check in all values (catches non-standard label placements)
-        return any(trace_identifier in str(v) for v in labels.values()) or \
-               any(trace_identifier in str(v) for v in annotations.values())
+        return any(trace_identifier in str(v) for v in labels.values()) or any(
+            trace_identifier in str(v) for v in annotations.values()
+        )
 
     elif trace_type == "pr":
         # Look for PR number in labels and annotations
         # Support multiple PAC label formats used by different Konflux/Tekton installations
         pr_keys = [
             "pac.test.appstudio.openshift.io/pull-request",  # Konflux/AppStudio PAC
-            "pipelinesascode.tekton.dev/pull-request",       # Standard PAC
+            "pipelinesascode.tekton.dev/pull-request",  # Standard PAC
             "pull-request",
-            "pr"
+            "pr",
         ]
         for key in pr_keys:
             if labels.get(key) == trace_identifier or annotations.get(key) == trace_identifier:
@@ -211,7 +232,7 @@ def matches_trace_identifier(pipeline_run: Dict[str, Any], trace_identifier: str
         # Also check annotation keys that might store PR info
         pr_annotation_keys = [
             "pipelinesascode.tekton.dev/pull-request",
-            "build.appstudio.openshift.io/pull_request_number"
+            "build.appstudio.openshift.io/pull_request_number",
         ]
         for key in pr_annotation_keys:
             if annotations.get(key) == trace_identifier:
@@ -220,15 +241,18 @@ def matches_trace_identifier(pipeline_run: Dict[str, Any], trace_identifier: str
 
     elif trace_type == "image":
         # Look for image reference in labels, annotations, or results
-        return any(trace_identifier in str(v) for v in labels.values()) or \
-               any(trace_identifier in str(v) for v in annotations.values())
+        return any(trace_identifier in str(v) for v in labels.values()) or any(
+            trace_identifier in str(v) for v in annotations.values()
+        )
 
     elif trace_type == "custom":
         # Search across all labels and annotations
         name = metadata.get("name", "")
-        return trace_identifier in name or \
-               any(trace_identifier in str(v) for v in labels.values()) or \
-               any(trace_identifier in str(v) for v in annotations.values())
+        return (
+            trace_identifier in name
+            or any(trace_identifier in str(v) for v in labels.values())
+            or any(trace_identifier in str(v) for v in annotations.values())
+        )
 
     return False
 
@@ -253,16 +277,20 @@ def extract_task_info(pipeline_run: Dict[str, Any]) -> List[Dict[str, Any]]:
     for task_run_name, task_run_status in task_runs.items():
         task_info = {
             "name": task_run_name,
-            "status": task_run_status.get("status", {}).get("conditions", [{}])[-1].get("reason", "Unknown"),
+            "status": task_run_status.get("status", {})
+            .get("conditions", [{}])[-1]
+            .get("reason", "Unknown"),
             "start_time": task_run_status.get("status", {}).get("startTime"),
-            "completion_time": task_run_status.get("status", {}).get("completionTime")
+            "completion_time": task_run_status.get("status", {}).get("completionTime"),
         }
         tasks.append(task_info)
 
     return tasks
 
 
-def in_time_range(pipeline_info: Dict[str, Any], start_time: Optional[str], end_time: Optional[str]) -> bool:
+def in_time_range(
+    pipeline_info: Dict[str, Any], start_time: Optional[str], end_time: Optional[str]
+) -> bool:
     """Check if pipeline execution falls within the specified time range."""
     if not start_time and not end_time:
         return True
@@ -272,15 +300,15 @@ def in_time_range(pipeline_info: Dict[str, Any], start_time: Optional[str], end_
         return True
 
     try:
-        pipeline_dt = datetime.fromisoformat(pipeline_start.replace('Z', '+00:00'))
+        pipeline_dt = datetime.fromisoformat(pipeline_start.replace("Z", "+00:00"))
 
         if start_time:
-            start_dt = datetime.fromisoformat(start_time.replace('Z', '+00:00'))
+            start_dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
             if pipeline_dt < start_dt:
                 return False
 
         if end_time:
-            end_dt = datetime.fromisoformat(end_time.replace('Z', '+00:00'))
+            end_dt = datetime.fromisoformat(end_time.replace("Z", "+00:00"))
             if pipeline_dt > end_dt:
                 return False
 
@@ -299,13 +327,14 @@ async def follow_lifecycle_chain(
     custom_api,
     core_api,
     trace_depth: str = "deep",
-    logger=None
+    logger=None,
 ) -> Dict[str, Any]:
     """
     Follow the Konflux lifecycle chain from build PLRs through snapshots,
     integration tests, releases, and release pipelines.
 
-    Chain: Build PLR → Snapshot → Integration Tests → Release → Managed/Tenant/Final PLR → Nudge Cascade
+    Chain: Build PLR -> Snapshot -> Integration Tests ->
+           Release -> Managed/Tenant/Final PLR -> Nudge Cascade
 
     Args:
         pipeline_flow: Initial matched PipelineRuns from correlate_pipeline_events()
@@ -317,7 +346,6 @@ async def follow_lifecycle_chain(
     Returns:
         Dict with snapshots, integration_tests, releases, release_pipelines, nudge_cascade
     """
-    import json
 
     lifecycle = {
         "application": None,
@@ -340,8 +368,9 @@ async def follow_lifecycle_chain(
 
         # ── Step 2: Build PLR → Snapshot ──
         # Check both annotations (build PLRs) and labels (test PLRs) for snapshot reference
-        snapshot_name = annotations.get("appstudio.openshift.io/snapshot") or \
-                        labels.get("appstudio.openshift.io/snapshot")
+        snapshot_name = annotations.get("appstudio.openshift.io/snapshot") or labels.get(
+            "appstudio.openshift.io/snapshot"
+        )
         if not snapshot_name or snapshot_name in seen_snapshots:
             continue
         seen_snapshots.add(snapshot_name)
@@ -355,12 +384,16 @@ async def follow_lifecycle_chain(
         if not lifecycle["application"]:
             app_name = snapshot_data.get("application")
             if app_name:
-                lifecycle["application"] = await _resolve_application(custom_api, namespace, app_name, logger)
+                lifecycle["application"] = await _resolve_application(
+                    custom_api, namespace, app_name, logger
+                )
 
         if not lifecycle["component"]:
             comp_name = labels.get("appstudio.openshift.io/component")
             if comp_name:
-                lifecycle["component"] = await _resolve_component(custom_api, namespace, comp_name, logger)
+                lifecycle["component"] = await _resolve_component(
+                    custom_api, namespace, comp_name, logger
+                )
 
         # ── Step 3: Snapshot → Integration Tests ──
         test_entries = _extract_test_info_from_snapshot(snapshot_data)
@@ -373,10 +406,16 @@ async def follow_lifecycle_chain(
                 )
                 if test_plr_detail:
                     test_entry["tasks"] = extract_task_info_from_status(test_plr_detail)
-                    test_entry["pipeline"] = test_plr_detail.get("metadata", {}).get("labels", {}).get("tekton.dev/pipeline", "")
+                    test_entry["pipeline"] = (
+                        test_plr_detail.get("metadata", {})
+                        .get("labels", {})
+                        .get("tekton.dev/pipeline", "")
+                    )
 
         # ── Step 4: Snapshot → Releases ──
-        releases = await _resolve_releases_for_snapshot(custom_api, namespace, snapshot_name, logger)
+        releases = await _resolve_releases_for_snapshot(
+            custom_api, namespace, snapshot_name, logger
+        )
         for release in releases:
             release_key = release.get("name", "")
             if release_key in seen_releases:
@@ -407,8 +446,11 @@ async def _resolve_plr(custom_api, namespace: str, plr_name: str, logger=None) -
     """Fetch a single PipelineRun resource."""
     try:
         return custom_api.get_namespaced_custom_object(
-            group="tekton.dev", version="v1",
-            namespace=namespace, plural="pipelineruns", name=plr_name
+            group="tekton.dev",
+            version="v1",
+            namespace=namespace,
+            plural="pipelineruns",
+            name=plr_name,
         )
     except Exception as e:
         if logger:
@@ -416,12 +458,17 @@ async def _resolve_plr(custom_api, namespace: str, plr_name: str, logger=None) -
         return None
 
 
-async def _resolve_application(custom_api, namespace: str, app_name: str, logger=None) -> Optional[Dict]:
+async def _resolve_application(
+    custom_api, namespace: str, app_name: str, logger=None
+) -> Optional[Dict]:
     """Fetch an Application resource and extract key fields."""
     try:
         app = custom_api.get_namespaced_custom_object(
-            group="appstudio.redhat.com", version="v1alpha1",
-            namespace=namespace, plural="applications", name=app_name
+            group="appstudio.redhat.com",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="applications",
+            name=app_name,
         )
         spec = app.get("spec", {})
 
@@ -429,9 +476,11 @@ async def _resolve_application(custom_api, namespace: str, app_name: str, logger
         component_count = 0
         try:
             comp_list = custom_api.list_namespaced_custom_object(
-                group="appstudio.redhat.com", version="v1alpha1",
-                namespace=namespace, plural="components",
-                label_selector=f"appstudio.openshift.io/application={app_name}"
+                group="appstudio.redhat.com",
+                version="v1alpha1",
+                namespace=namespace,
+                plural="components",
+                label_selector=f"appstudio.openshift.io/application={app_name}",
             )
             component_count = len(comp_list.get("items", []))
         except Exception:
@@ -449,12 +498,17 @@ async def _resolve_application(custom_api, namespace: str, app_name: str, logger
         return {"name": app_name, "namespace": namespace, "status": "not_found"}
 
 
-async def _resolve_component(custom_api, namespace: str, comp_name: str, logger=None) -> Optional[Dict]:
+async def _resolve_component(
+    custom_api, namespace: str, comp_name: str, logger=None
+) -> Optional[Dict]:
     """Fetch a Component resource and extract key fields."""
     try:
         comp = custom_api.get_namespaced_custom_object(
-            group="appstudio.redhat.com", version="v1alpha1",
-            namespace=namespace, plural="components", name=comp_name
+            group="appstudio.redhat.com",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="components",
+            name=comp_name,
         )
         spec = comp.get("spec", {})
         status = comp.get("status", {})
@@ -464,7 +518,10 @@ async def _resolve_component(custom_api, namespace: str, comp_name: str, logger=
         build_pipeline = ""
         try:
             import json
-            pipeline_info = json.loads(annotations.get("build.appstudio.openshift.io/pipeline", "{}"))
+
+            pipeline_info = json.loads(
+                annotations.get("build.appstudio.openshift.io/pipeline", "{}")
+            )
             build_pipeline = pipeline_info.get("name", "")
         except Exception:
             pass
@@ -473,6 +530,7 @@ async def _resolve_component(custom_api, namespace: str, comp_name: str, logger=
         pac_enabled = False
         try:
             import json
+
             pac_info = json.loads(annotations.get("build.appstudio.openshift.io/status", "{}"))
             pac_enabled = pac_info.get("pac", {}).get("state") == "enabled"
         except Exception:
@@ -499,13 +557,17 @@ async def _resolve_component(custom_api, namespace: str, comp_name: str, logger=
         return {"name": comp_name, "namespace": namespace, "status": "not_found"}
 
 
-async def _resolve_snapshot(custom_api, namespace: str, snapshot_name: str, source_plr: Dict, logger=None) -> Optional[Dict]:
+async def _resolve_snapshot(
+    custom_api, namespace: str, snapshot_name: str, source_plr: Dict, logger=None
+) -> Optional[Dict]:
     """Fetch a Snapshot resource and extract key fields."""
-    import json
     try:
         snapshot = custom_api.get_namespaced_custom_object(
-            group="appstudio.redhat.com", version="v1alpha1",
-            namespace=namespace, plural="snapshots", name=snapshot_name
+            group="appstudio.redhat.com",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="snapshots",
+            name=snapshot_name,
         )
         metadata = snapshot.get("metadata", {})
         annotations = metadata.get("annotations", {})
@@ -525,12 +587,14 @@ async def _resolve_snapshot(custom_api, namespace: str, snapshot_name: str, sour
         # Extract components
         components = []
         for comp in spec.get("components", []):
-            components.append({
-                "name": comp.get("name", ""),
-                "containerImage": comp.get("containerImage", "")[:100],
-                "git_url": comp.get("source", {}).get("git", {}).get("url", ""),
-                "revision": comp.get("source", {}).get("git", {}).get("revision", "")[:12],
-            })
+            components.append(
+                {
+                    "name": comp.get("name", ""),
+                    "containerImage": comp.get("containerImage", "")[:100],
+                    "git_url": comp.get("source", {}).get("git", {}).get("url", ""),
+                    "revision": comp.get("source", {}).get("git", {}).get("revision", "")[:12],
+                }
+            )
 
         return {
             "name": snapshot_name,
@@ -541,7 +605,10 @@ async def _resolve_snapshot(custom_api, namespace: str, snapshot_name: str, sour
             "conditions": condition_map,
             "tests_passed": condition_map.get("AppStudioTestSucceeded", {}).get("status") == "True",
             "auto_released": condition_map.get("AutoReleased", {}).get("status") == "True",
-            "nudge_processed": annotations.get("build.appstudio.openshift.io/component-nudge-processed") == "true",
+            "nudge_processed": annotations.get(
+                "build.appstudio.openshift.io/component-nudge-processed"
+            )
+            == "true",
             "triggered_by_plr": source_plr.get("pipeline_run_name", ""),
             "created_at": metadata.get("creationTimestamp", ""),
             "_raw_annotations": annotations,  # Kept for test extraction
@@ -549,7 +616,9 @@ async def _resolve_snapshot(custom_api, namespace: str, snapshot_name: str, sour
     except Exception as e:
         if logger:
             logger.debug(f"Failed to resolve snapshot {snapshot_name} in {namespace}: {e}")
-        status_msg = "not_found" if "404" in str(e) else "rbac_denied" if "403" in str(e) else str(e)[:80]
+        status_msg = (
+            "not_found" if "404" in str(e) else "rbac_denied" if "403" in str(e) else str(e)[:80]
+        )
         return {
             "name": snapshot_name,
             "namespace": namespace,
@@ -567,6 +636,7 @@ async def _resolve_snapshot(custom_api, namespace: str, snapshot_name: str, sour
 def _extract_test_info_from_snapshot(snapshot_data: Dict) -> List[Dict]:
     """Extract integration test results from snapshot annotations."""
     import json
+
     tests = []
     raw_annotations = snapshot_data.get("_raw_annotations", {})
     test_status_str = raw_annotations.get("test.appstudio.openshift.io/status", "[]")
@@ -583,38 +653,45 @@ def _extract_test_info_from_snapshot(snapshot_data: Dict) -> List[Dict]:
         if start_time and completion_time:
             try:
                 from datetime import datetime
+
                 s = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
                 e = datetime.fromisoformat(completion_time.replace("Z", "+00:00"))
                 duration_seconds = int((e - s).total_seconds())
             except Exception:
                 pass
 
-        tests.append({
-            "scenario": test.get("scenario", ""),
-            "status": test.get("status", ""),
-            "plr_name": test.get("testPipelineRunName", ""),
-            "start_time": start_time,
-            "completion_time": completion_time,
-            "duration_seconds": duration_seconds,
-            "snapshot": snapshot_data.get("name", ""),
-        })
+        tests.append(
+            {
+                "scenario": test.get("scenario", ""),
+                "status": test.get("status", ""),
+                "plr_name": test.get("testPipelineRunName", ""),
+                "start_time": start_time,
+                "completion_time": completion_time,
+                "duration_seconds": duration_seconds,
+                "snapshot": snapshot_data.get("name", ""),
+            }
+        )
 
     return tests
 
 
-async def _resolve_releases_for_snapshot(custom_api, namespace: str, snapshot_name: str, logger=None) -> List[Dict]:
+async def _resolve_releases_for_snapshot(
+    custom_api, namespace: str, snapshot_name: str, logger=None
+) -> List[Dict]:
     """Find Release resources linked to a snapshot via label."""
     releases = []
     try:
         release_list = custom_api.list_namespaced_custom_object(
-            group="appstudio.redhat.com", version="v1alpha1",
-            namespace=namespace, plural="releases",
-            label_selector=f"release.appstudio.openshift.io/snapshot={snapshot_name}"
+            group="appstudio.redhat.com",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="releases",
+            label_selector=f"release.appstudio.openshift.io/snapshot={snapshot_name}",
         )
 
         for release in release_list.get("items", []):
             metadata = release.get("metadata", {})
-            labels = metadata.get("labels", {})
+            metadata.get("labels", {})
             spec = release.get("spec", {})
             status = release.get("status", {})
             conditions = status.get("conditions", [])
@@ -627,25 +704,31 @@ async def _resolve_releases_for_snapshot(custom_api, namespace: str, snapshot_na
                     "message": c.get("message", "")[:200],
                 }
 
-            releases.append({
-                "name": metadata.get("name", ""),
-                "namespace": namespace,
-                "snapshot": snapshot_name,
-                "release_plan": spec.get("releasePlan", ""),
-                "grace_period_days": spec.get("gracePeriodDays"),
-                "status": "Succeeded" if condition_map.get("Released", {}).get("status") == "True" else "Failed" if condition_map.get("Released", {}).get("status") == "False" else "InProgress",
-                "conditions": condition_map,
-                "automated": status.get("automated", False),
-                "author": status.get("attribution", {}).get("author", ""),
-                "start_time": status.get("startTime"),
-                "completion_time": status.get("completionTime"),
-                "target": status.get("target", ""),
-                "artifacts": status.get("artifacts", {}),
-                # Pipeline references for step 5
-                "_managed_plr_ref": status.get("managedProcessing", {}).get("pipelineRun"),
-                "_tenant_plr_ref": status.get("tenantProcessing", {}).get("pipelineRun"),
-                "_final_plr_ref": status.get("finalProcessing", {}).get("pipelineRun"),
-            })
+            releases.append(
+                {
+                    "name": metadata.get("name", ""),
+                    "namespace": namespace,
+                    "snapshot": snapshot_name,
+                    "release_plan": spec.get("releasePlan", ""),
+                    "grace_period_days": spec.get("gracePeriodDays"),
+                    "status": "Succeeded"
+                    if condition_map.get("Released", {}).get("status") == "True"
+                    else "Failed"
+                    if condition_map.get("Released", {}).get("status") == "False"
+                    else "InProgress",
+                    "conditions": condition_map,
+                    "automated": status.get("automated", False),
+                    "author": status.get("attribution", {}).get("author", ""),
+                    "start_time": status.get("startTime"),
+                    "completion_time": status.get("completionTime"),
+                    "target": status.get("target", ""),
+                    "artifacts": status.get("artifacts", {}),
+                    # Pipeline references for step 5
+                    "_managed_plr_ref": status.get("managedProcessing", {}).get("pipelineRun"),
+                    "_tenant_plr_ref": status.get("tenantProcessing", {}).get("pipelineRun"),
+                    "_final_plr_ref": status.get("finalProcessing", {}).get("pipelineRun"),
+                }
+            )
 
     except Exception as e:
         if logger:
@@ -670,8 +753,7 @@ async def _resolve_release_pipelines(custom_api, release: Dict, logger=None) -> 
 
         try:
             plr = custom_api.get_namespaced_custom_object(
-                group="tekton.dev", version="v1",
-                namespace=ns, plural="pipelineruns", name=name
+                group="tekton.dev", version="v1", namespace=ns, plural="pipelineruns", name=name
             )
             status = plr.get("status", {})
             conditions = status.get("conditions", [])
@@ -693,38 +775,51 @@ async def _resolve_release_pipelines(custom_api, release: Dict, logger=None) -> 
             if start and end:
                 try:
                     from datetime import datetime
+
                     s = datetime.fromisoformat(start.replace("Z", "+00:00"))
                     e = datetime.fromisoformat(end.replace("Z", "+00:00"))
                     duration_seconds = int((e - s).total_seconds())
                 except Exception:
                     pass
 
-            plrs.append({
-                "name": name,
-                "namespace": ns,
-                "stage": stage,
-                "pipeline": plr.get("metadata", {}).get("labels", {}).get("tekton.dev/pipeline", ""),
-                "status": plr_status,
-                "message": plr_message[:150],
-                "start_time": start,
-                "completion_time": end,
-                "duration_seconds": duration_seconds,
-                "tasks": tasks,
-                "task_count": len(tasks),
-                "release": release.get("name", ""),
-            })
+            plrs.append(
+                {
+                    "name": name,
+                    "namespace": ns,
+                    "stage": stage,
+                    "pipeline": plr.get("metadata", {})
+                    .get("labels", {})
+                    .get("tekton.dev/pipeline", ""),
+                    "status": plr_status,
+                    "message": plr_message[:150],
+                    "start_time": start,
+                    "completion_time": end,
+                    "duration_seconds": duration_seconds,
+                    "tasks": tasks,
+                    "task_count": len(tasks),
+                    "release": release.get("name", ""),
+                }
+            )
 
         except Exception as e:
             if logger:
                 logger.debug(f"Failed to resolve {stage} PLR {ns}/{name}: {e}")
-            status_msg = "not_found" if "404" in str(e) else "rbac_denied" if "403" in str(e) else str(e)[:60]
-            plrs.append({
-                "name": name,
-                "namespace": ns,
-                "stage": stage,
-                "status": status_msg,
-                "release": release.get("name", ""),
-            })
+            status_msg = (
+                "not_found"
+                if "404" in str(e)
+                else "rbac_denied"
+                if "403" in str(e)
+                else str(e)[:60]
+            )
+            plrs.append(
+                {
+                    "name": name,
+                    "namespace": ns,
+                    "stage": stage,
+                    "status": status_msg,
+                    "release": release.get("name", ""),
+                }
+            )
 
     return plrs
 
@@ -737,10 +832,12 @@ def extract_task_info_from_status(plr: Dict) -> List[Dict]:
     child_refs = plr.get("status", {}).get("childReferences", [])
     if child_refs:
         for ref in child_refs:
-            tasks.append({
-                "name": ref.get("pipelineTaskName", ref.get("name", "")),
-                "taskrun_name": ref.get("name", ""),
-            })
+            tasks.append(
+                {
+                    "name": ref.get("pipelineTaskName", ref.get("name", "")),
+                    "taskrun_name": ref.get("name", ""),
+                }
+            )
         return tasks
 
     # Fall back to inline taskRuns (v1beta1 format)
@@ -756,24 +853,29 @@ def extract_task_info_from_status(plr: Dict) -> List[Dict]:
         if start and end:
             try:
                 from datetime import datetime
+
                 s = datetime.fromisoformat(start.replace("Z", "+00:00"))
                 e = datetime.fromisoformat(end.replace("Z", "+00:00"))
                 duration = int((e - s).total_seconds())
             except Exception:
                 pass
 
-        tasks.append({
-            "name": task_run_name,
-            "status": result,
-            "start_time": start,
-            "completion_time": end,
-            "duration_seconds": duration,
-        })
+        tasks.append(
+            {
+                "name": task_run_name,
+                "status": result,
+                "start_time": start,
+                "completion_time": end,
+                "duration_seconds": duration,
+            }
+        )
 
     return tasks
 
 
-async def _resolve_nudge_cascade(custom_api, namespace: str, snapshot_data: Dict, releases: List[Dict], logger=None) -> List[Dict]:
+async def _resolve_nudge_cascade(
+    custom_api, namespace: str, snapshot_data: Dict, releases: List[Dict], logger=None
+) -> List[Dict]:
     """Find downstream build PLRs triggered by component nudge after a release."""
     nudge_entries = []
 
@@ -784,6 +886,7 @@ async def _resolve_nudge_cascade(custom_api, namespace: str, snapshot_data: Dict
         if comp_time:
             try:
                 from datetime import datetime
+
                 dt = datetime.fromisoformat(comp_time.replace("Z", "+00:00"))
                 if latest_completion is None or dt > latest_completion:
                     latest_completion = dt
@@ -796,9 +899,7 @@ async def _resolve_nudge_cascade(custom_api, namespace: str, snapshot_data: Dict
     try:
         # List recent PLRs in the same namespace
         plr_list = custom_api.list_namespaced_custom_object(
-            group="tekton.dev", version="v1",
-            namespace=namespace, plural="pipelineruns",
-            limit=50
+            group="tekton.dev", version="v1", namespace=namespace, plural="pipelineruns", limit=50
         )
 
         for plr in plr_list.get("items", []):
@@ -810,8 +911,9 @@ async def _resolve_nudge_cascade(custom_api, namespace: str, snapshot_data: Dict
             # Check if this PLR was created after the release and is a nudge-triggered build
             sender = annotations.get("pipelinesascode.tekton.dev/sender", "")
             title = annotations.get("pipelinesascode.tekton.dev/sha-title", "")
-            is_nudge = ("konflux" in sender.lower() or "red-hat-konflux" in sender.lower()) and \
-                       ("chore(deps)" in title.lower() or "update" in title.lower())
+            is_nudge = ("konflux" in sender.lower() or "red-hat-konflux" in sender.lower()) and (
+                "chore(deps)" in title.lower() or "update" in title.lower()
+            )
 
             if not is_nudge:
                 continue
@@ -819,6 +921,7 @@ async def _resolve_nudge_cascade(custom_api, namespace: str, snapshot_data: Dict
             # Check creation time is after the release
             try:
                 from datetime import datetime
+
                 created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
                 if created_dt <= latest_completion:
                     continue
@@ -829,14 +932,16 @@ async def _resolve_nudge_cascade(custom_api, namespace: str, snapshot_data: Dict
             status_conds = plr.get("status", {}).get("conditions", [])
             plr_status = status_conds[0].get("reason", "Unknown") if status_conds else "Unknown"
 
-            nudge_entries.append({
-                "plr_name": metadata.get("name", ""),
-                "component": component,
-                "status": plr_status,
-                "triggered_at": created,
-                "title": title[:100],
-                "sender": sender[:40],
-            })
+            nudge_entries.append(
+                {
+                    "plr_name": metadata.get("name", ""),
+                    "component": component,
+                    "status": plr_status,
+                    "triggered_at": created,
+                    "title": title[:100],
+                    "sender": sender[:40],
+                }
+            )
 
     except Exception as e:
         if logger:
@@ -849,9 +954,10 @@ async def _resolve_nudge_cascade(custom_api, namespace: str, snapshot_data: Dict
 # ARTIFACT TRACKING AND ANALYSIS
 # ============================================================================
 
-async def track_artifacts(pipeline_flow: List[Dict[str, Any]],
-                          include_artifacts: bool = True,
-                          logger=None) -> List[Dict[str, Any]]:
+
+async def track_artifacts(
+    pipeline_flow: List[Dict[str, Any]], include_artifacts: bool = True, logger=None
+) -> List[Dict[str, Any]]:
     """Track artifacts through container registries and pipeline results."""
     if not include_artifacts:
         return []
@@ -872,7 +978,10 @@ async def track_artifacts(pipeline_flow: List[Dict[str, Any]],
 
         except Exception as e:
             if logger:
-                logger.debug(f"Failed to track artifacts for pipeline {pipeline.get('pipeline_name', '')}: {e}")
+                logger.debug(
+                    f"Failed to track artifacts for pipeline "
+                    f"{pipeline.get('pipeline_name', '')}: {e}"
+                )
             continue
 
     return artifacts
@@ -900,19 +1009,21 @@ def extract_pipeline_artifacts(pipeline: Dict[str, Any]) -> List[Dict[str, Any]]
 
     for image in potential_images:
         if image and ":" in image:  # Basic image validation
-            artifacts.append({
-                "artifact_id": image,
-                "type": "container_image",
-                "registry": image.split("/")[0] if "/" in image else "unknown",
-                "propagation_path": [
-                    {
-                        "cluster": pipeline["cluster"],
-                        "namespace": pipeline["namespace"],
-                        "pipeline": pipeline["pipeline_name"],
-                        "timestamp": pipeline.get("start_time", "")
-                    }
-                ]
-            })
+            artifacts.append(
+                {
+                    "artifact_id": image,
+                    "type": "container_image",
+                    "registry": image.split("/")[0] if "/" in image else "unknown",
+                    "propagation_path": [
+                        {
+                            "cluster": pipeline["cluster"],
+                            "namespace": pipeline["namespace"],
+                            "pipeline": pipeline["pipeline_name"],
+                            "timestamp": pipeline.get("start_time", ""),
+                        }
+                    ],
+                }
+            )
 
     return artifacts
 
@@ -920,6 +1031,7 @@ def extract_pipeline_artifacts(pipeline: Dict[str, Any]) -> List[Dict[str, Any]]
 # ============================================================================
 # PERFORMANCE ANALYSIS AND BOTTLENECK DETECTION
 # ============================================================================
+
 
 def analyze_bottlenecks(pipeline_flow: List[Dict[str, Any]], logger=None) -> List[Dict[str, Any]]:
     """Analyze pipeline flow for bottlenecks and performance issues."""
@@ -932,18 +1044,28 @@ def analyze_bottlenecks(pipeline_flow: List[Dict[str, Any]], logger=None) -> Lis
 
             if start_time and completion_time:
                 try:
-                    start_dt = datetime.fromisoformat(start_time.replace('Z', '+00:00'))
-                    end_dt = datetime.fromisoformat(completion_time.replace('Z', '+00:00'))
+                    start_dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+                    end_dt = datetime.fromisoformat(completion_time.replace("Z", "+00:00"))
                     duration = (end_dt - start_dt).total_seconds()
 
                     # Flag pipelines that take unusually long (> 30 minutes)
                     if duration > 1800:
-                        bottlenecks.append({
-                            "location": f"{pipeline['cluster']}/{pipeline['namespace']}/{pipeline['pipeline_name']}",
-                            "type": "long_duration",
-                            "duration": duration,
-                            "description": f"Pipeline execution took {duration/60:.1f} minutes"
-                        })
+                        cluster = pipeline["cluster"]
+                        ns = pipeline["namespace"]
+                        pname = pipeline["pipeline_name"]
+                        loc = f"{cluster}/{ns}/{pname}"
+                        dur_min = duration / 60
+                        bottlenecks.append(
+                            {
+                                "location": loc,
+                                "type": "long_duration",
+                                "duration": duration,
+                                "description": (
+                                    f"Pipeline execution took "
+                                    f"{dur_min:.1f} minutes"
+                                ),
+                            }
+                        )
 
                     # Check task-level bottlenecks
                     for task in pipeline.get("tasks", []):
@@ -952,18 +1074,32 @@ def analyze_bottlenecks(pipeline_flow: List[Dict[str, Any]], logger=None) -> Lis
 
                         if task_start and task_end:
                             try:
-                                task_start_dt = datetime.fromisoformat(task_start.replace('Z', '+00:00'))
-                                task_end_dt = datetime.fromisoformat(task_end.replace('Z', '+00:00'))
+                                task_start_dt = datetime.fromisoformat(
+                                    task_start.replace("Z", "+00:00")
+                                )
+                                task_end_dt = datetime.fromisoformat(
+                                    task_end.replace("Z", "+00:00")
+                                )
                                 task_duration = (task_end_dt - task_start_dt).total_seconds()
 
                                 # Flag tasks that take more than 15 minutes
                                 if task_duration > 900:
-                                    bottlenecks.append({
-                                        "location": f"{pipeline['cluster']}/{pipeline['namespace']}/{task['name']}",
-                                        "type": "slow_task",
-                                        "duration": task_duration,
-                                        "description": f"Task '{task['name']}' took {task_duration/60:.1f} minutes"
-                                    })
+                                    cluster = pipeline["cluster"]
+                                    ns = pipeline["namespace"]
+                                    tname = task["name"]
+                                    loc = f"{cluster}/{ns}/{tname}"
+                                    td_min = task_duration / 60
+                                    bottlenecks.append(
+                                        {
+                                            "location": loc,
+                                            "type": "slow_task",
+                                            "duration": task_duration,
+                                            "description": (
+                                                f"Task '{tname}' took "
+                                                f"{td_min:.1f} minutes"
+                                            ),
+                                        }
+                                    )
                             except Exception:
                                 continue
 
@@ -973,13 +1109,22 @@ def analyze_bottlenecks(pipeline_flow: List[Dict[str, Any]], logger=None) -> Lis
         # Look for patterns across the flow
         if len(pipeline_flow) > 1:
             # Check for frequent failures
-            failed_pipelines = [p for p in pipeline_flow if p.get("status", "").lower() in ["failed", "error"]]
+            failed_pipelines = [
+                p for p in pipeline_flow if p.get("status", "").lower() in ["failed", "error"]
+            ]
             if len(failed_pipelines) / len(pipeline_flow) > 0.3:
-                bottlenecks.append({
-                    "location": "cross_cluster",
-                    "type": "high_failure_rate",
-                    "description": f"High failure rate: {len(failed_pipelines)}/{len(pipeline_flow)} pipelines failed"
-                })
+                bottlenecks.append(
+                    {
+                        "location": "cross_cluster",
+                        "type": "high_failure_rate",
+                        "description": (
+                            f"High failure rate: "
+                            f"{len(failed_pipelines)}/"
+                            f"{len(pipeline_flow)} "
+                            "pipelines failed"
+                        ),
+                    }
+                )
 
     except Exception as e:
         if logger:
@@ -991,6 +1136,7 @@ def analyze_bottlenecks(pipeline_flow: List[Dict[str, Any]], logger=None) -> Lis
 # ============================================================================
 # MACHINE CONFIG POOL ANALYSIS
 # ============================================================================
+
 
 def analyze_machine_config_pool_status(pool: Dict[str, Any]) -> Dict[str, Any]:
     """Analyze machine config pool status and extract key information."""
@@ -1021,7 +1167,7 @@ def analyze_machine_config_pool_status(pool: Dict[str, Any]) -> Dict[str, Any]:
             "machine_config_selector": spec.get("machineConfigSelector", {}),
             "node_selector": spec.get("nodeSelector", {}),
             "paused": spec.get("paused", False),
-            "max_unavailable": spec.get("maxUnavailable", "1")
+            "max_unavailable": spec.get("maxUnavailable", "1"),
         }
 
         # Extract conditions
@@ -1034,8 +1180,10 @@ def analyze_machine_config_pool_status(pool: Dict[str, Any]) -> Dict[str, Any]:
                 "ready_machines": ready_machine_count,
                 "updated_machines": updated_machine_count,
                 "degraded_machines": degraded_machine_count,
-                "progress_percentage": round((updated_machine_count / machine_count) * 100, 2) if machine_count > 0 else 0,
-                "is_updating": machine_count != updated_machine_count
+                "progress_percentage": round((updated_machine_count / machine_count) * 100, 2)
+                if machine_count > 0
+                else 0,
+                "is_updating": machine_count != updated_machine_count,
             }
         else:
             update_progress = {
@@ -1044,7 +1192,7 @@ def analyze_machine_config_pool_status(pool: Dict[str, Any]) -> Dict[str, Any]:
                 "updated_machines": 0,
                 "degraded_machines": 0,
                 "progress_percentage": 0,
-                "is_updating": False
+                "is_updating": False,
             }
 
         return {
@@ -1055,7 +1203,7 @@ def analyze_machine_config_pool_status(pool: Dict[str, Any]) -> Dict[str, Any]:
             "configuration": configuration,
             "conditions": conditions,
             "update_progress": update_progress,
-            "node_status": []  # Will be populated later if requested
+            "node_status": [],  # Will be populated later if requested
         }
 
     except Exception as e:
@@ -1068,7 +1216,7 @@ def analyze_machine_config_pool_status(pool: Dict[str, Any]) -> Dict[str, Any]:
             "conditions": [],
             "update_progress": {},
             "node_status": [],
-            "error": str(e)
+            "error": str(e),
         }
 
 
@@ -1083,27 +1231,31 @@ def detect_pool_issues(pool_analysis: Dict[str, Any]) -> List[Dict[str, Any]]:
     # Check for degraded status
     if status == "degraded":
         degraded_count = update_progress.get("degraded_machines", 0)
-        issues.append({
-            "pool": name,
-            "issue_type": "degraded_machines",
-            "description": f"Pool has {degraded_count} degraded machine(s)",
-            "affected_nodes": [],  # Would need node details to populate
-            "severity": "high" if degraded_count > 1 else "medium",
-            "remediation": "Check individual node status and machine config application logs"
-        })
+        issues.append(
+            {
+                "pool": name,
+                "issue_type": "degraded_machines",
+                "description": f"Pool has {degraded_count} degraded machine(s)",
+                "affected_nodes": [],  # Would need node details to populate
+                "severity": "high" if degraded_count > 1 else "medium",
+                "remediation": "Check individual node status and machine config application logs",
+            }
+        )
 
     # Check for stuck updates
     if update_progress.get("is_updating", False):
         progress_pct = update_progress.get("progress_percentage", 0)
         if progress_pct < 100:
-            issues.append({
-                "pool": name,
-                "issue_type": "update_in_progress",
-                "description": f"Update in progress: {progress_pct}% complete",
-                "affected_nodes": [],
-                "severity": "low",
-                "remediation": "Monitor update progress and check for any stuck nodes"
-            })
+            issues.append(
+                {
+                    "pool": name,
+                    "issue_type": "update_in_progress",
+                    "description": f"Update in progress: {progress_pct}% complete",
+                    "affected_nodes": [],
+                    "severity": "low",
+                    "remediation": "Monitor update progress and check for any stuck nodes",
+                }
+            )
 
     # Check conditions for specific issues
     for condition in conditions:
@@ -1113,23 +1265,27 @@ def detect_pool_issues(pool_analysis: Dict[str, Any]) -> List[Dict[str, Any]]:
         condition_message = condition.get("message", "")
 
         if condition_type == "NodeDegraded" and condition_status == "True":
-            issues.append({
-                "pool": name,
-                "issue_type": "node_degraded",
-                "description": f"Node degraded: {condition_message}",
-                "affected_nodes": [],
-                "severity": "high",
-                "remediation": f"Investigate degraded condition: {condition_reason}"
-            })
+            issues.append(
+                {
+                    "pool": name,
+                    "issue_type": "node_degraded",
+                    "description": f"Node degraded: {condition_message}",
+                    "affected_nodes": [],
+                    "severity": "high",
+                    "remediation": f"Investigate degraded condition: {condition_reason}",
+                }
+            )
         elif condition_type == "RenderDegraded" and condition_status == "True":
-            issues.append({
-                "pool": name,
-                "issue_type": "render_degraded",
-                "description": f"Configuration rendering failed: {condition_message}",
-                "affected_nodes": [],
-                "severity": "high",
-                "remediation": "Check machine config rendering and template validation"
-            })
+            issues.append(
+                {
+                    "pool": name,
+                    "issue_type": "render_degraded",
+                    "description": f"Configuration rendering failed: {condition_message}",
+                    "affected_nodes": [],
+                    "severity": "high",
+                    "remediation": "Check machine config rendering and template validation",
+                }
+            )
 
     return issues
 
@@ -1146,32 +1302,44 @@ def generate_update_recommendations(pools_analysis: List[Dict[str, Any]]) -> Lis
 
         # Recommendation for degraded pools
         if status == "degraded":
-            recommendations.append({
-                "pool": name,
-                "recommendation": "Investigate and resolve degraded machines immediately",
-                "reasoning": "Degraded machines can impact cluster stability and workload scheduling",
-                "urgency": "high"
-            })
+            recommendations.append(
+                {
+                    "pool": name,
+                    "recommendation": "Investigate and resolve degraded machines immediately",
+                    "reasoning": (
+                        "Degraded machines can impact cluster "
+                        "stability and workload scheduling"
+                    ),
+                    "urgency": "high",
+                }
+            )
 
         # Recommendation for paused pools
         if configuration.get("paused", False):
-            recommendations.append({
-                "pool": name,
-                "recommendation": "Review paused pool status and resume updates if appropriate",
-                "reasoning": "Paused pools may miss critical security and stability updates",
-                "urgency": "medium"
-            })
+            recommendations.append(
+                {
+                    "pool": name,
+                    "recommendation": "Review paused pool status and resume updates if appropriate",
+                    "reasoning": "Paused pools may miss critical security and stability updates",
+                    "urgency": "medium",
+                }
+            )
 
         # Recommendation for stuck updates
         if update_progress.get("is_updating", False):
             progress_pct = update_progress.get("progress_percentage", 0)
             if progress_pct > 0 and progress_pct < 100:
-                recommendations.append({
-                    "pool": name,
-                    "recommendation": "Monitor update progress and check for stuck nodes",
-                    "reasoning": f"Update is {progress_pct}% complete but may require intervention",
-                    "urgency": "low"
-                })
+                recommendations.append(
+                    {
+                        "pool": name,
+                        "recommendation": "Monitor update progress and check for stuck nodes",
+                        "reasoning": (
+                            f"Update is {progress_pct}% complete "
+                            "but may require intervention"
+                        ),
+                        "urgency": "low",
+                    }
+                )
 
     return recommendations
 
@@ -1179,6 +1347,7 @@ def generate_update_recommendations(pools_analysis: List[Dict[str, Any]]) -> Lis
 # ============================================================================
 # OPERATOR ANALYSIS
 # ============================================================================
+
 
 def analyze_operator_dependencies(operators: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Analyze operator dependencies and relationships."""
@@ -1194,7 +1363,7 @@ def analyze_operator_dependencies(operators: List[Dict[str, Any]]) -> List[Dict[
         "openshift-apiserver": ["etcd", "kube-apiserver-operator"],
         "openshift-controller-manager": ["openshift-apiserver"],
         "machine-api": ["cluster-autoscaler-operator"],
-        "cluster-autoscaler-operator": ["machine-api"]
+        "cluster-autoscaler-operator": ["machine-api"],
     }
 
     operator_names = {op.get("name", "") for op in operators}
@@ -1214,15 +1383,16 @@ def analyze_operator_dependencies(operators: List[Dict[str, Any]]) -> List[Dict[
                 if dep_operator:
                     conditions = dep_operator.get("conditions", [])
                     for condition in conditions:
-                        if condition.get("type") in ["Degraded", "Available"] and condition.get("status") != "True":
+                        if (
+                            condition.get("type") in ["Degraded", "Available"]
+                            and condition.get("status") != "True"
+                        ):
                             dep_status = "unhealthy"
                             break
 
-            dependencies.append({
-                "operator": op_name,
-                "depends_on": existing_deps,
-                "dependency_status": dep_status
-            })
+            dependencies.append(
+                {"operator": op_name, "depends_on": existing_deps, "dependency_status": dep_status}
+            )
 
     return dependencies
 
@@ -1248,22 +1418,38 @@ def identify_critical_issues(operators: List[Dict[str, Any]]) -> List[Dict[str, 
 
         if health == "critical":
             for cond in critical_conditions:
-                critical_issues.append({
-                    "operator": op_name,
-                    "severity": "critical",
-                    "issue": cond.get("message", "Operator is degraded"),
-                    "impact": f"Operator {op_name} failure may affect cluster functionality",
-                    "recommended_action": f"Investigate and resolve {op_name} operator issues immediately"
-                })
+                critical_issues.append(
+                    {
+                        "operator": op_name,
+                        "severity": "critical",
+                        "issue": cond.get("message", "Operator is degraded"),
+                        "impact": (
+                            f"Operator {op_name} failure may "
+                            "affect cluster functionality"
+                        ),
+                        "recommended_action": (
+                            f"Investigate and resolve {op_name} "
+                            "operator issues immediately"
+                        ),
+                    }
+                )
         elif health == "warning":
             for cond in warning_conditions:
-                critical_issues.append({
-                    "operator": op_name,
-                    "severity": "warning",
-                    "issue": cond.get("message", "Operator is not available"),
-                    "impact": f"Operator {op_name} availability issues may affect functionality",
-                    "recommended_action": f"Monitor and investigate {op_name} operator availability"
-                })
+                critical_issues.append(
+                    {
+                        "operator": op_name,
+                        "severity": "warning",
+                        "issue": cond.get("message", "Operator is not available"),
+                        "impact": (
+                            f"Operator {op_name} availability "
+                            "issues may affect functionality"
+                        ),
+                        "recommended_action": (
+                            f"Monitor and investigate {op_name} "
+                            "operator availability"
+                        ),
+                    }
+                )
 
     return critical_issues
 
@@ -1276,7 +1462,7 @@ def analyze_operator_conditions(conditions: List[Dict[str, Any]]) -> Dict[str, A
         "degraded": False,
         "critical_conditions": [],
         "warning_conditions": [],
-        "healthy_conditions": []
+        "healthy_conditions": [],
     }
 
     for condition in conditions:
@@ -1294,22 +1480,17 @@ def analyze_operator_conditions(conditions: List[Dict[str, Any]]) -> Dict[str, A
 
         # Categorize conditions by severity
         if status == "True" and condition_type in ["Degraded", "Failed"]:
-            condition_summary["critical_conditions"].append({
-                "type": condition_type,
-                "message": message,
-                "reason": reason
-            })
+            condition_summary["critical_conditions"].append(
+                {"type": condition_type, "message": message, "reason": reason}
+            )
         elif status == "Unknown" or (status == "False" and condition_type in ["Available"]):
-            condition_summary["warning_conditions"].append({
-                "type": condition_type,
-                "message": message,
-                "reason": reason
-            })
+            condition_summary["warning_conditions"].append(
+                {"type": condition_type, "message": message, "reason": reason}
+            )
         else:
-            condition_summary["healthy_conditions"].append({
-                "type": condition_type,
-                "status": status
-            })
+            condition_summary["healthy_conditions"].append(
+                {"type": condition_type, "status": status}
+            )
 
     return condition_summary
 
@@ -1318,7 +1499,10 @@ def analyze_operator_conditions(conditions: List[Dict[str, Any]]) -> Dict[str, A
 # TOPOLOGY MAPPING UTILITIES
 # ============================================================================
 
-async def get_multi_cluster_topology_clients(k8s_core_api, k8s_custom_api, k8s_apps_api, k8s_storage_api, k8s_batch_api) -> Dict[str, Dict[str, Any]]:
+
+async def get_multi_cluster_topology_clients(
+    k8s_core_api, k8s_custom_api, k8s_apps_api, k8s_storage_api, k8s_batch_api
+) -> Dict[str, Dict[str, Any]]:
     """Get authenticated clients for multiple clusters for topology mapping."""
     # For now, return the current cluster - extend this for actual multi-cluster setups
     return {
@@ -1327,7 +1511,7 @@ async def get_multi_cluster_topology_clients(k8s_core_api, k8s_custom_api, k8s_a
             "custom_api": k8s_custom_api,
             "apps_api": k8s_apps_api,
             "storage_api": k8s_storage_api,
-            "batch_api": k8s_batch_api
+            "batch_api": k8s_batch_api,
         }
     }
 
@@ -1355,7 +1539,9 @@ def calculate_dependency_weight(source_type: str, target_type: str, relationship
     return weight_matrix.get(key, 0.5)
 
 
-async def get_resource_metrics(cluster_name: str, resource_type: str, namespace: str, name: str, logger) -> Dict[str, Any]:
+async def get_resource_metrics(
+    cluster_name: str, resource_type: str, namespace: str, name: str, logger
+) -> Dict[str, Any]:
     """Get real-time metrics for a resource."""
     try:
         # This would integrate with Prometheus in a real implementation
@@ -1364,14 +1550,16 @@ async def get_resource_metrics(cluster_name: str, resource_type: str, namespace:
             "cpu_usage": "0.1",
             "memory_usage": "64Mi",
             "status": "running",
-            "last_updated": datetime.now().isoformat()
+            "last_updated": datetime.now().isoformat(),
         }
     except Exception as e:
         logger.debug(f"Could not fetch metrics for {resource_type}/{name}: {e}")
         return {}
 
 
-async def analyze_owner_references(resource: Dict[str, Any], cluster: str, resource_type: str) -> List[Dict[str, str]]:
+async def analyze_owner_references(
+    resource: Dict[str, Any], cluster: str, resource_type: str
+) -> List[Dict[str, str]]:
     """Analyze Kubernetes OwnerReferences to find parent-child relationships.
 
     Args:
@@ -1399,26 +1587,30 @@ async def analyze_owner_references(resource: Dict[str, Any], cluster: str, resou
             cluster,
             resource.get("metadata", {}).get("namespace", "default"),
             owner_kind,
-            owner_name
+            owner_name,
         )
         target_id = generate_node_id(
             cluster,
             resource.get("metadata", {}).get("namespace", "default"),
             resource_type,
-            resource.get("metadata", {}).get("name", "")
+            resource.get("metadata", {}).get("name", ""),
         )
 
-        edges.append({
-            "source": source_id,
-            "target": target_id,
-            "relationship": "owns",
-            "weight": calculate_dependency_weight(owner_kind, resource_type, "owns")
-        })
+        edges.append(
+            {
+                "source": source_id,
+                "target": target_id,
+                "relationship": "owns",
+                "weight": calculate_dependency_weight(owner_kind, resource_type, "owns"),
+            }
+        )
 
     return edges
 
 
-async def analyze_service_dependencies(service: Dict[str, Any], cluster: str, core_api, logger, pods_list=None) -> List[Dict[str, str]]:
+async def analyze_service_dependencies(
+    service: Dict[str, Any], cluster: str, core_api, logger, pods_list=None
+) -> List[Dict[str, str]]:
     """Analyze service selector relationships to pods.
 
     Args:
@@ -1442,6 +1634,7 @@ async def analyze_service_dependencies(service: Dict[str, Any], cluster: str, co
             pods_items = pods_list
         else:
             import asyncio
+
             pods = await asyncio.to_thread(core_api.list_namespaced_pod, namespace=namespace)
             pods_items = pods.items
 
@@ -1450,16 +1643,19 @@ async def analyze_service_dependencies(service: Dict[str, Any], cluster: str, co
 
             # Check if all selector labels match pod labels
             if all(pod_labels.get(key) == value for key, value in selector.items()):
-                service_id = generate_node_id(cluster, namespace, "service",
-                                             service.get("metadata", {}).get("name", ""))
+                service_id = generate_node_id(
+                    cluster, namespace, "service", service.get("metadata", {}).get("name", "")
+                )
                 pod_id = generate_node_id(cluster, namespace, "pod", pod.metadata.name)
 
-                edges.append({
-                    "source": service_id,
-                    "target": pod_id,
-                    "relationship": "routes_to",
-                    "weight": calculate_dependency_weight("service", "pod", "routes_to")
-                })
+                edges.append(
+                    {
+                        "source": service_id,
+                        "target": pod_id,
+                        "relationship": "routes_to",
+                        "weight": calculate_dependency_weight("service", "pod", "routes_to"),
+                    }
+                )
 
     except Exception as e:
         logger.debug(f"Error analyzing service dependencies: {e}")
@@ -1467,7 +1663,9 @@ async def analyze_service_dependencies(service: Dict[str, Any], cluster: str, co
     return edges
 
 
-async def analyze_volume_dependencies(resource: Dict[str, Any], cluster: str, resource_type: str, logger) -> List[Dict[str, str]]:
+async def analyze_volume_dependencies(
+    resource: Dict[str, Any], cluster: str, resource_type: str, logger
+) -> List[Dict[str, str]]:
     """Analyze volume mount dependencies.
 
     Args:
@@ -1493,20 +1691,26 @@ async def analyze_volume_dependencies(resource: Dict[str, Any], cluster: str, re
 
         for volume in volumes:
             source_id = generate_node_id(cluster, namespace, resource_type, resource_name)
-            volume_name = volume.get("name", "")
+            volume.get("name", "")
 
             # Check for PVC references (handle both camelCase and snake_case)
             pvc_ref = volume.get("persistentVolumeClaim") or volume.get("persistent_volume_claim")
             if pvc_ref:
                 pvc_name = pvc_ref.get("claimName") or pvc_ref.get("claim_name", "")
                 if pvc_name:
-                    target_id = generate_node_id(cluster, namespace, "persistentvolumeclaim", pvc_name)
-                    edges.append({
-                        "source": source_id,
-                        "target": target_id,
-                        "relationship": "mounts",
-                        "weight": calculate_dependency_weight(resource_type, "persistentvolumeclaim", "mounts")
-                    })
+                    target_id = generate_node_id(
+                        cluster, namespace, "persistentvolumeclaim", pvc_name
+                    )
+                    edges.append(
+                        {
+                            "source": source_id,
+                            "target": target_id,
+                            "relationship": "mounts",
+                            "weight": calculate_dependency_weight(
+                                resource_type, "persistentvolumeclaim", "mounts"
+                            ),
+                        }
+                    )
 
             # Check for ConfigMap references (handle both camelCase and snake_case)
             cm_ref = volume.get("configMap") or volume.get("config_map")
@@ -1514,12 +1718,16 @@ async def analyze_volume_dependencies(resource: Dict[str, Any], cluster: str, re
                 cm_name = cm_ref.get("name", "")
                 if cm_name:
                     target_id = generate_node_id(cluster, namespace, "configmap", cm_name)
-                    edges.append({
-                        "source": source_id,
-                        "target": target_id,
-                        "relationship": "mounts",
-                        "weight": calculate_dependency_weight(resource_type, "configmap", "mounts")
-                    })
+                    edges.append(
+                        {
+                            "source": source_id,
+                            "target": target_id,
+                            "relationship": "mounts",
+                            "weight": calculate_dependency_weight(
+                                resource_type, "configmap", "mounts"
+                            ),
+                        }
+                    )
 
             # Check for Secret references
             secret_ref = volume.get("secret")
@@ -1527,12 +1735,16 @@ async def analyze_volume_dependencies(resource: Dict[str, Any], cluster: str, re
                 secret_name = secret_ref.get("secretName") or secret_ref.get("secret_name", "")
                 if secret_name:
                     target_id = generate_node_id(cluster, namespace, "secret", secret_name)
-                    edges.append({
-                        "source": source_id,
-                        "target": target_id,
-                        "relationship": "mounts",
-                        "weight": calculate_dependency_weight(resource_type, "secret", "mounts")
-                    })
+                    edges.append(
+                        {
+                            "source": source_id,
+                            "target": target_id,
+                            "relationship": "mounts",
+                            "weight": calculate_dependency_weight(
+                                resource_type, "secret", "mounts"
+                            ),
+                        }
+                    )
 
             # Check for projected volumes (can include ConfigMaps and Secrets)
             projected = volume.get("projected")
@@ -1543,23 +1755,31 @@ async def analyze_volume_dependencies(resource: Dict[str, Any], cluster: str, re
                         cm_name = cm_src.get("name", "")
                         if cm_name:
                             target_id = generate_node_id(cluster, namespace, "configmap", cm_name)
-                            edges.append({
-                                "source": source_id,
-                                "target": target_id,
-                                "relationship": "mounts",
-                                "weight": calculate_dependency_weight(resource_type, "configmap", "mounts")
-                            })
+                            edges.append(
+                                {
+                                    "source": source_id,
+                                    "target": target_id,
+                                    "relationship": "mounts",
+                                    "weight": calculate_dependency_weight(
+                                        resource_type, "configmap", "mounts"
+                                    ),
+                                }
+                            )
                     if "secret" in source:
                         secret_src = source.get("secret", {})
                         secret_name = secret_src.get("name", "")
                         if secret_name:
                             target_id = generate_node_id(cluster, namespace, "secret", secret_name)
-                            edges.append({
-                                "source": source_id,
-                                "target": target_id,
-                                "relationship": "mounts",
-                                "weight": calculate_dependency_weight(resource_type, "secret", "mounts")
-                            })
+                            edges.append(
+                                {
+                                    "source": source_id,
+                                    "target": target_id,
+                                    "relationship": "mounts",
+                                    "weight": calculate_dependency_weight(
+                                        resource_type, "secret", "mounts"
+                                    ),
+                                }
+                            )
 
     except Exception as e:
         logger.debug(f"Error analyzing volume dependencies: {e}")
@@ -1576,8 +1796,10 @@ async def analyze_volume_dependencies(resource: Dict[str, Any], cluster: str, re
 # PERMISSION-AWARE RESOURCE FETCHING
 # ============================================================================
 
-def handle_resource_fetch_error(e: Exception, resource_type: str, namespace: str,
-                                skip_on_permission_denied: bool, logger) -> Dict[str, Any]:
+
+def handle_resource_fetch_error(
+    e: Exception, resource_type: str, namespace: str, skip_on_permission_denied: bool, logger
+) -> Dict[str, Any]:
     """
     Handle errors during resource fetching with permission-aware logic.
 
@@ -1586,20 +1808,22 @@ def handle_resource_fetch_error(e: Exception, resource_type: str, namespace: str
     """
     from kubernetes.client.rest import ApiException
 
-    result = {
-        "success": False,
-        "permission_denied": False,
-        "error_message": str(e)
-    }
+    result = {"success": False, "permission_denied": False, "error_message": str(e)}
 
     if isinstance(e, ApiException):
         if e.status == 403:
             # Permission denied
             result["permission_denied"] = True
-            logger.info(f"Permission denied for {resource_type} in namespace {namespace} (403 Forbidden)")
+            logger.info(
+                f"Permission denied for {resource_type} in namespace {namespace} (403 Forbidden)"
+            )
 
             if skip_on_permission_denied:
-                logger.debug(f"Skipping {resource_type} due to permission denied (skip_on_permission_denied=True)")
+                logger.debug(
+                    f"Skipping {resource_type} due to "
+                    "permission denied "
+                    "(skip_on_permission_denied=True)"
+                )
             else:
                 logger.warning(f"Permission denied for {resource_type} in namespace {namespace}")
         elif e.status == 404:
@@ -1607,7 +1831,10 @@ def handle_resource_fetch_error(e: Exception, resource_type: str, namespace: str
             logger.debug(f"Resource type {resource_type} not found in namespace {namespace} (404)")
         else:
             # Other API error
-            logger.warning(f"API error fetching {resource_type} in namespace {namespace}: {e.status} - {e.reason}")
+            logger.warning(
+                f"API error fetching {resource_type} in "
+                f"namespace {namespace}: {e.status} - {e.reason}"
+            )
     else:
         # Non-API exception
         logger.error(f"Unexpected error fetching {resource_type} in namespace {namespace}: {e}")
@@ -1622,7 +1849,7 @@ async def identify_affected_components(
     k8s_core_api,
     k8s_apps_api,
     list_pods,
-    list_namespaces
+    list_namespaces,
 ) -> List[Dict[str, Any]]:
     """Identify components that will be affected by the proposed changes."""
     from kubernetes.client.rest import ApiException
@@ -1648,14 +1875,16 @@ async def identify_affected_components(
                             "namespace": namespace,
                             "impact_type": "scaling",
                             "severity": "medium",
-                            "details": f"Deployment with {deployment.status.replicas} replicas"
+                            "details": f"Deployment with {deployment.status.replicas} replicas",
                         }
 
                         # Check if this deployment matches any change criteria
                         for change_key, change_value in changes.items():
                             if change_key.lower() in deployment.metadata.name.lower():
                                 component_info["severity"] = "high"
-                                component_info["details"] += f" - directly affected by {change_key} changes"
+                                component_info["details"] += (
+                                    f" - directly affected by {change_key} changes"
+                                )
                                 break
 
                         affected_components.append(component_info)
@@ -1671,19 +1900,23 @@ async def identify_affected_components(
                                 "namespace": namespace,
                                 "impact_type": "resource_limits",
                                 "severity": "medium",
-                                "details": f"Pod with {len(pod.get('containers', []))} containers"
+                                "details": f"Pod with {len(pod.get('containers', []))} containers",
                             }
 
                             # Check for resource-constrained containers
-                            containers = pod.get('containers', [])
+                            containers = pod.get("containers", [])
                             constrained_containers = 0
                             for container in containers:
-                                if container.get('state') in ['Waiting', 'Terminated']:
+                                if container.get("state") in ["Waiting", "Terminated"]:
                                     constrained_containers += 1
 
                             if constrained_containers > 0:
                                 component_info["severity"] = "high"
-                                component_info["details"] += f" - {constrained_containers} containers show resource constraints"
+                                component_info["details"] += (
+                                    f" - {constrained_containers} "
+                                    "containers show resource "
+                                    "constraints"
+                                )
 
                             affected_components.append(component_info)
 
@@ -1696,7 +1929,7 @@ async def identify_affected_components(
                             "namespace": namespace,
                             "impact_type": scenario_type,
                             "severity": "low",
-                            "details": f"Service with {len(service.spec.ports or [])} ports"
+                            "details": f"Service with {len(service.spec.ports or [])} ports",
                         }
 
                         # Higher severity for services with many endpoints
@@ -1714,12 +1947,20 @@ async def identify_affected_components(
 
     except Exception as e:
         logger.error(f"Error identifying affected components: {e}")
-        return [{"component": "unknown", "impact_type": "error", "severity": "unknown", "details": str(e)}]
+        return [
+            {
+                "component": "unknown",
+                "impact_type": "error",
+                "severity": "unknown",
+                "details": str(e),
+            }
+        ]
 
 
 # ============================================================================
 # TOPOLOGY OUTPUT FORMAT CONVERTERS
 # ============================================================================
+
 
 def convert_to_graphviz(nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]) -> str:
     """Convert topology to Graphviz DOT format."""
@@ -1762,6 +2003,6 @@ def convert_to_mermaid(nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]])
         source_id = edge["source"].replace(":", "_").replace("/", "_")
         target_id = edge["target"].replace(":", "_").replace("/", "_")
         relationship = edge.get("relationship", "")
-        mermaid.append(f'  {source_id} -->|{relationship}| {target_id}')
+        mermaid.append(f"  {source_id} -->|{relationship}| {target_id}")
 
     return "\n".join(mermaid)

--- a/src/helpers/semantic_search.py
+++ b/src/helpers/semantic_search.py
@@ -16,19 +16,36 @@ from collections import defaultdict
 # QUERY INTERPRETATION AND PROCESSING
 # ============================================================================
 
+
 def interpret_semantic_query(query: str, time_range: str) -> Dict[str, Any]:
     """Interpret natural language query using domain knowledge and NLP concepts."""
     query_lower = query.lower()
 
     # Domain-specific intent patterns
     intent_patterns = {
-        'error_investigation': ['error', 'fail', 'crash', 'exception', 'problem', 'issue', 'broken'],
-        'performance_analysis': ['slow', 'performance', 'latency', 'timeout', 'bottleneck', 'cpu', 'memory'],
-        'deployment_tracking': ['deploy', 'rollout', 'update', 'release', 'version', 'upgrade'],
-        'pipeline_monitoring': ['pipeline', 'build', 'test', 'ci/cd', 'tekton', 'task'],
-        'resource_monitoring': ['resource', 'quota', 'limit', 'capacity', 'usage', 'allocation'],
-        'security_audit': ['security', 'permission', 'access', 'auth', 'rbac', 'token'],
-        'network_debugging': ['network', 'connection', 'dns', 'service', 'ingress', 'route']
+        "error_investigation": [
+            "error",
+            "fail",
+            "crash",
+            "exception",
+            "problem",
+            "issue",
+            "broken",
+        ],
+        "performance_analysis": [
+            "slow",
+            "performance",
+            "latency",
+            "timeout",
+            "bottleneck",
+            "cpu",
+            "memory",
+        ],
+        "deployment_tracking": ["deploy", "rollout", "update", "release", "version", "upgrade"],
+        "pipeline_monitoring": ["pipeline", "build", "test", "ci/cd", "tekton", "task"],
+        "resource_monitoring": ["resource", "quota", "limit", "capacity", "usage", "allocation"],
+        "security_audit": ["security", "permission", "access", "auth", "rbac", "token"],
+        "network_debugging": ["network", "connection", "dns", "service", "ingress", "route"],
     }
 
     # Determine primary intent
@@ -38,16 +55,18 @@ def interpret_semantic_query(query: str, time_range: str) -> Dict[str, Any]:
         if score > 0:
             intent_scores[intent] = score
 
-    primary_intent = max(intent_scores, key=intent_scores.get) if intent_scores else 'general_search'
+    primary_intent = (
+        max(intent_scores, key=intent_scores.get) if intent_scores else "general_search"
+    )
 
     # Extract temporal indicators
     temporal_indicators = {
-        'recent': ['recent', 'latest', 'new', 'just', 'now'],
-        'ongoing': ['current', 'active', 'running', 'ongoing'],
-        'historical': ['yesterday', 'last week', 'previous', 'old', 'past']
+        "recent": ["recent", "latest", "new", "just", "now"],
+        "ongoing": ["current", "active", "running", "ongoing"],
+        "historical": ["yesterday", "last week", "previous", "old", "past"],
     }
 
-    temporal_context = 'recent'  # default
+    temporal_context = "recent"  # default
     for context, keywords in temporal_indicators.items():
         if any(keyword in query_lower for keyword in keywords):
             temporal_context = context
@@ -57,32 +76,39 @@ def interpret_semantic_query(query: str, time_range: str) -> Dict[str, Any]:
     interpreted_intent = _build_interpreted_intent(primary_intent, query_lower, temporal_context)
 
     return {
-        'original_query': query,
-        'primary_intent': primary_intent,
-        'interpreted_intent': interpreted_intent,
-        'temporal_context': temporal_context,
-        'intent_confidence': max(intent_scores.values()) if intent_scores else 0,
-        'semantic_keywords': _extract_semantic_keywords(query_lower, primary_intent)
+        "original_query": query,
+        "primary_intent": primary_intent,
+        "interpreted_intent": interpreted_intent,
+        "temporal_context": temporal_context,
+        "intent_confidence": max(intent_scores.values()) if intent_scores else 0,
+        "semantic_keywords": _extract_semantic_keywords(query_lower, primary_intent),
     }
 
 
-def _build_interpreted_intent(primary_intent: str, query_lower: str, temporal_context: str) -> str:
+def _build_interpreted_intent(
+    primary_intent: str, query_lower: str, temporal_context: str
+) -> str:
     """Build human-readable interpretation of the query intent."""
+    tp = _get_temporal_phrase(temporal_context)
     intent_templates = {
-        'error_investigation': f"Investigating errors and failures{_get_temporal_phrase(temporal_context)}",
-        'performance_analysis': f"Analyzing performance issues{_get_temporal_phrase(temporal_context)}",
-        'deployment_tracking': f"Tracking deployment activities{_get_temporal_phrase(temporal_context)}",
-        'pipeline_monitoring': f"Monitoring CI/CD pipeline execution{_get_temporal_phrase(temporal_context)}",
-        'resource_monitoring': f"Monitoring resource usage and limits{_get_temporal_phrase(temporal_context)}",
-        'security_audit': f"Auditing security and access patterns{_get_temporal_phrase(temporal_context)}",
-        'network_debugging': f"Debugging network connectivity issues{_get_temporal_phrase(temporal_context)}",
-        'general_search': f"General log search{_get_temporal_phrase(temporal_context)}"
+        "error_investigation": f"Investigating errors and failures{tp}",
+        "performance_analysis": f"Analyzing performance issues{tp}",
+        "deployment_tracking": f"Tracking deployment activities{tp}",
+        "pipeline_monitoring": f"Monitoring CI/CD pipeline execution{tp}",
+        "resource_monitoring": f"Monitoring resource usage and limits{tp}",
+        "security_audit": f"Auditing security and access patterns{tp}",
+        "network_debugging": f"Debugging network connectivity issues{tp}",
+        "general_search": f"General log search{tp}",
     }
 
     base_intent = intent_templates.get(primary_intent, "General log analysis")
 
     # Add specific query elements
-    specific_terms = [word for word in query_lower.split() if len(word) > 3 and word not in ['error', 'logs', 'find', 'show', 'get']]
+    specific_terms = [
+        word
+        for word in query_lower.split()
+        if len(word) > 3 and word not in ["error", "logs", "find", "show", "get"]
+    ]
     if specific_terms:
         base_intent += f" focusing on: {', '.join(specific_terms[:3])}"
 
@@ -92,11 +118,11 @@ def _build_interpreted_intent(primary_intent: str, query_lower: str, temporal_co
 def _get_temporal_phrase(temporal_context: str) -> str:
     """Get temporal phrase for intent description."""
     phrases = {
-        'recent': ' in recent activity',
-        'ongoing': ' in current operations',
-        'historical': ' from historical data'
+        "recent": " in recent activity",
+        "ongoing": " in current operations",
+        "historical": " from historical data",
     }
-    return phrases.get(temporal_context, '')
+    return phrases.get(temporal_context, "")
 
 
 def _extract_semantic_keywords(query_lower: str, primary_intent: str) -> List[str]:
@@ -106,13 +132,13 @@ def _extract_semantic_keywords(query_lower: str, primary_intent: str) -> List[st
 
     # Intent-specific keyword expansion
     keyword_expansions = {
-        'error_investigation': ['exception', 'fault', 'crash', 'failure', 'bug'],
-        'performance_analysis': ['slow', 'latency', 'response', 'throughput', 'bottleneck'],
-        'deployment_tracking': ['rollout', 'release', 'version', 'update', 'deploy'],
-        'pipeline_monitoring': ['build', 'test', 'stage', 'run', 'execute'],
-        'resource_monitoring': ['cpu', 'memory', 'disk', 'quota', 'limit'],
-        'security_audit': ['auth', 'permission', 'access', 'security', 'token'],
-        'network_debugging': ['connection', 'dns', 'timeout', 'route', 'service']
+        "error_investigation": ["exception", "fault", "crash", "failure", "bug"],
+        "performance_analysis": ["slow", "latency", "response", "throughput", "bottleneck"],
+        "deployment_tracking": ["rollout", "release", "version", "update", "deploy"],
+        "pipeline_monitoring": ["build", "test", "stage", "run", "execute"],
+        "resource_monitoring": ["cpu", "memory", "disk", "quota", "limit"],
+        "security_audit": ["auth", "permission", "access", "security", "token"],
+        "network_debugging": ["connection", "dns", "timeout", "route", "service"],
     }
 
     expanded_keywords = base_keywords + keyword_expansions.get(primary_intent, [])
@@ -123,50 +149,52 @@ def _extract_semantic_keywords(query_lower: str, primary_intent: str) -> List[st
 # SEARCH STRATEGY DETERMINATION
 # ============================================================================
 
+
 def determine_search_strategy(query_interpretation: Dict[str, Any]) -> Dict[str, Any]:
     """Determine optimal search strategy based on query interpretation."""
-    primary_intent = query_interpretation['primary_intent']
-    confidence = query_interpretation['intent_confidence']
+    primary_intent = query_interpretation["primary_intent"]
+    confidence = query_interpretation["intent_confidence"]
 
     strategy_map = {
-        'error_investigation': 'error_focused_search',
-        'performance_analysis': 'metrics_and_logs_search',
-        'deployment_tracking': 'event_timeline_search',
-        'pipeline_monitoring': 'pipeline_lifecycle_search',
-        'resource_monitoring': 'resource_pattern_search',
-        'security_audit': 'security_event_search',
-        'network_debugging': 'network_trace_search',
-        'general_search': 'broad_semantic_search'
+        "error_investigation": "error_focused_search",
+        "performance_analysis": "metrics_and_logs_search",
+        "deployment_tracking": "event_timeline_search",
+        "pipeline_monitoring": "pipeline_lifecycle_search",
+        "resource_monitoring": "resource_pattern_search",
+        "security_audit": "security_event_search",
+        "network_debugging": "network_trace_search",
+        "general_search": "broad_semantic_search",
     }
 
-    strategy = strategy_map.get(primary_intent, 'broad_semantic_search')
+    strategy = strategy_map.get(primary_intent, "broad_semantic_search")
 
     return {
-        'strategy': strategy,
-        'confidence': confidence,
-        'search_scope': 'targeted' if confidence > 2 else 'broad',
-        'priority_sources': _get_priority_sources(primary_intent)
+        "strategy": strategy,
+        "confidence": confidence,
+        "search_scope": "targeted" if confidence > 2 else "broad",
+        "priority_sources": _get_priority_sources(primary_intent),
     }
 
 
 def _get_priority_sources(primary_intent: str) -> List[str]:
     """Get priority log sources based on intent."""
     source_priority = {
-        'error_investigation': ['pods', 'events', 'controller-logs'],
-        'performance_analysis': ['metrics', 'pods', 'system-logs'],
-        'deployment_tracking': ['events', 'controller-logs', 'pods'],
-        'pipeline_monitoring': ['pipelineruns', 'taskruns', 'pods'],
-        'resource_monitoring': ['metrics', 'events', 'quota-logs'],
-        'security_audit': ['audit-logs', 'events', 'rbac-logs'],
-        'network_debugging': ['service-logs', 'dns-logs', 'ingress-logs'],
-        'general_search': ['pods', 'events', 'controller-logs']
+        "error_investigation": ["pods", "events", "controller-logs"],
+        "performance_analysis": ["metrics", "pods", "system-logs"],
+        "deployment_tracking": ["events", "controller-logs", "pods"],
+        "pipeline_monitoring": ["pipelineruns", "taskruns", "pods"],
+        "resource_monitoring": ["metrics", "events", "quota-logs"],
+        "security_audit": ["audit-logs", "events", "rbac-logs"],
+        "network_debugging": ["service-logs", "dns-logs", "ingress-logs"],
+        "general_search": ["pods", "events", "controller-logs"],
     }
-    return source_priority.get(primary_intent, ['pods', 'events'])
+    return source_priority.get(primary_intent, ["pods", "events"])
 
 
 # ============================================================================
 # ENTITY EXTRACTION
 # ============================================================================
+
 
 def extract_k8s_entities(query: str) -> List[str]:
     """Extract Kubernetes/Tekton entities from query using domain knowledge."""
@@ -174,34 +202,34 @@ def extract_k8s_entities(query: str) -> List[str]:
 
     # Kubernetes entities
     k8s_entities = {
-        'pod': ['pod', 'pods'],
-        'service': ['service', 'services', 'svc'],
-        'deployment': ['deployment', 'deployments', 'deploy'],
-        'namespace': ['namespace', 'namespaces', 'ns'],
-        'configmap': ['configmap', 'configmaps', 'cm'],
-        'secret': ['secret', 'secrets'],
-        'ingress': ['ingress', 'ingresses'],
-        'node': ['node', 'nodes'],
-        'persistentvolume': ['pv', 'persistentvolume', 'volume'],
-        'persistentvolumeclaim': ['pvc', 'persistentvolumeclaim', 'claim']
+        "pod": ["pod", "pods"],
+        "service": ["service", "services", "svc"],
+        "deployment": ["deployment", "deployments", "deploy"],
+        "namespace": ["namespace", "namespaces", "ns"],
+        "configmap": ["configmap", "configmaps", "cm"],
+        "secret": ["secret", "secrets"],
+        "ingress": ["ingress", "ingresses"],
+        "node": ["node", "nodes"],
+        "persistentvolume": ["pv", "persistentvolume", "volume"],
+        "persistentvolumeclaim": ["pvc", "persistentvolumeclaim", "claim"],
     }
 
     # Tekton entities
     tekton_entities = {
-        'pipelinerun': ['pipelinerun', 'pipelineruns', 'pr'],
-        'taskrun': ['taskrun', 'taskruns', 'tr'],
-        'pipeline': ['pipeline', 'pipelines'],
-        'task': ['task', 'tasks'],
-        'clustertask': ['clustertask', 'clustertasks']
+        "pipelinerun": ["pipelinerun", "pipelineruns", "pr"],
+        "taskrun": ["taskrun", "taskruns", "tr"],
+        "pipeline": ["pipeline", "pipelines"],
+        "task": ["task", "tasks"],
+        "clustertask": ["clustertask", "clustertasks"],
     }
 
     # CI/CD and OpenShift specific
     cicd_entities = {
-        'application': ['application', 'applications', 'app'],
-        'component': ['component', 'components'],
-        'integration': ['integration', 'integrations'],
-        'release': ['release', 'releases'],
-        'snapshot': ['snapshot', 'snapshots']
+        "application": ["application", "applications", "app"],
+        "component": ["component", "components"],
+        "integration": ["integration", "integrations"],
+        "release": ["release", "releases"],
+        "snapshot": ["snapshot", "snapshots"],
     }
 
     all_entities = {**k8s_entities, **tekton_entities, **cicd_entities}
@@ -218,12 +246,13 @@ def extract_k8s_entities(query: str) -> List[str]:
 # SEMANTIC MATCHING AND RELEVANCE
 # ============================================================================
 
+
 def find_semantic_matches(
     lines: List[str],
     semantic_keywords: List[str],
     primary_intent: str,
     max_results: int = 50,
-    original_query_terms: Optional[List[str]] = None
+    original_query_terms: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Find semantically relevant matches in log lines."""
     matches = []
@@ -235,18 +264,22 @@ def find_semantic_matches(
 
         if relevance_score > 0.3:  # Threshold for relevance
             timestamp, level = extract_log_metadata(line)
-            matches.append({
-                'line_number': i + 1,
-                'content': line.strip(),
-                'relevance_score': relevance_score,
-                'timestamp': timestamp,
-                'log_level': level,
-                'match_reasons': identify_match_reasons(line, semantic_keywords, primary_intent),
-                'related_count': _count_related_entries(lines, i, semantic_keywords)
-            })
+            matches.append(
+                {
+                    "line_number": i + 1,
+                    "content": line.strip(),
+                    "relevance_score": relevance_score,
+                    "timestamp": timestamp,
+                    "log_level": level,
+                    "match_reasons": identify_match_reasons(
+                        line, semantic_keywords, primary_intent
+                    ),
+                    "related_count": _count_related_entries(lines, i, semantic_keywords),
+                }
+            )
 
     # Sort by relevance score descending so best matches come first
-    matches.sort(key=lambda x: x['relevance_score'], reverse=True)
+    matches.sort(key=lambda x: x["relevance_score"], reverse=True)
     return matches[:max_results]
 
 
@@ -254,7 +287,7 @@ def calculate_semantic_relevance(
     line: str,
     semantic_keywords: List[str],
     primary_intent: str,
-    original_query_terms: Optional[List[str]] = None
+    original_query_terms: Optional[List[str]] = None,
 ) -> float:
     """Calculate semantic relevance score for a log line.
 
@@ -277,13 +310,13 @@ def calculate_semantic_relevance(
 
     # Intent-specific patterns (lower weight to avoid generic "error" dominating)
     intent_patterns = {
-        'error_investigation': ['error', 'exception', 'fail', 'crash', 'panic', 'fatal'],
-        'performance_analysis': ['slow', 'timeout', 'latency', 'cpu', 'memory', 'performance'],
-        'deployment_tracking': ['deploy', 'rollout', 'update', 'version', 'release'],
-        'pipeline_monitoring': ['pipeline', 'task', 'build', 'test', 'stage'],
-        'resource_monitoring': ['resource', 'quota', 'limit', 'usage'],
-        'security_audit': ['permission', 'access', 'auth', 'security', 'forbidden'],
-        'network_debugging': ['connection', 'dns', 'network', 'timeout', 'refused']
+        "error_investigation": ["error", "exception", "fail", "crash", "panic", "fatal"],
+        "performance_analysis": ["slow", "timeout", "latency", "cpu", "memory", "performance"],
+        "deployment_tracking": ["deploy", "rollout", "update", "version", "release"],
+        "pipeline_monitoring": ["pipeline", "task", "build", "test", "stage"],
+        "resource_monitoring": ["resource", "quota", "limit", "usage"],
+        "security_audit": ["permission", "access", "auth", "security", "forbidden"],
+        "network_debugging": ["connection", "dns", "network", "timeout", "refused"],
     }
 
     patterns = intent_patterns.get(primary_intent, [])
@@ -292,8 +325,14 @@ def calculate_semantic_relevance(
 
     # Severity-based scoring: prefer error/warn over info for error-focused searches
     severity_indicators = {
-        'error': 0.8, 'fatal': 0.9, 'panic': 0.9, 'exception': 0.7,
-        'warn': 0.6, 'warning': 0.6, 'info': 0.1, 'debug': 0.05
+        "error": 0.8,
+        "fatal": 0.9,
+        "panic": 0.9,
+        "exception": 0.7,
+        "warn": 0.6,
+        "warning": 0.6,
+        "info": 0.1,
+        "debug": 0.05,
     }
 
     for indicator, weight in severity_indicators.items():
@@ -302,11 +341,11 @@ def calculate_semantic_relevance(
             break
 
     # Timestamp presence
-    if re.search(r'\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}', line):
+    if re.search(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}", line):
         score += 0.05
 
     # Structured log indicators
-    if any(char in line for char in ['{', '}', '=', ':']):
+    if any(char in line for char in ["{", "}", "=", ":"]):
         score += 0.05
 
     # Penalty: if user provided specific query terms but none matched,
@@ -318,9 +357,7 @@ def calculate_semantic_relevance(
 
 
 def identify_match_reasons(
-    line: str,
-    semantic_keywords: List[str],
-    primary_intent: str
+    line: str, semantic_keywords: List[str], primary_intent: str
 ) -> List[str]:
     """Identify why a log line matched the semantic search."""
     reasons = []
@@ -332,24 +369,28 @@ def identify_match_reasons(
         reasons.append(f"Keywords: {', '.join(matched_keywords)}")
 
     # Intent patterns
-    if 'error' in line_lower or 'exception' in line_lower:
+    if "error" in line_lower or "exception" in line_lower:
         reasons.append("Error pattern detected")
 
-    if 'warn' in line_lower:
+    if "warn" in line_lower:
         reasons.append("Warning pattern detected")
 
-    if primary_intent == 'performance_analysis' and any(word in line_lower for word in ['slow', 'timeout', 'latency']):
+    if primary_intent == "performance_analysis" and any(
+        word in line_lower for word in ["slow", "timeout", "latency"]
+    ):
         reasons.append("Performance issue indicators")
 
-    if primary_intent == 'deployment_tracking' and any(word in line_lower for word in ['deploy', 'rollout', 'update']):
+    if primary_intent == "deployment_tracking" and any(
+        word in line_lower for word in ["deploy", "rollout", "update"]
+    ):
         reasons.append("Deployment activity indicators")
 
     # Structured data
-    if re.search(r'\{.*\}', line):
+    if re.search(r"\{.*\}", line):
         reasons.append("Structured JSON log")
 
     # Timestamp presence
-    if re.search(r'\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}', line):
+    if re.search(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}", line):
         reasons.append("Timestamped entry")
 
     return reasons if reasons else ["General relevance"]
@@ -362,88 +403,104 @@ def extract_log_metadata(line: str) -> Tuple[str, str]:
     log level keywords in their message content (e.g., 'error handling').
     """
     # Extract timestamp
-    timestamp_match = re.search(r'(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)', line)
-    timestamp = timestamp_match.group(1) if timestamp_match else 'unknown'
+    timestamp_match = re.search(
+        r"(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)", line
+    )
+    timestamp = timestamp_match.group(1) if timestamp_match else "unknown"
 
     # Extract log level using positional patterns
     # Priority order: fatal/panic first, then error, warn, info, debug, trace
-    level = 'info'  # default
+    level = "info"  # default
     line_lower = line.lower()
 
     # Pattern 1: Log level at start of line (after optional timestamp)
     # Matches: "ERROR: ...", "2024-01-24 10:30:00 ERROR ...", "10:30:00.123 error ..."
+    # optional timestamp
+    ts_re = r"(?:\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}"
+    ts_re += r"(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\s+)?"
+    # optional time-only
+    time_re = r"(?:\d{2}:\d{2}:\d{2}(?:\.\d+)?\s+)?"
+    level_re = (
+        r"(fatal|panic|critical|error|err|warn"
+        r"|warning|info|debug|trace)\b"
+    )
     start_pattern = re.match(
-        r'^(?:\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\s+)?'  # optional timestamp
-        r'(?:\d{2}:\d{2}:\d{2}(?:\.\d+)?\s+)?'  # optional time-only
-        r'(fatal|panic|critical|error|err|warn|warning|info|debug|trace)\b',
-        line_lower
+        r"^" + ts_re + time_re + level_re,
+        line_lower,
     )
     if start_pattern:
         matched = start_pattern.group(1)
-        if matched in ('fatal', 'panic', 'critical'):
-            return timestamp, 'fatal'
-        elif matched in ('error', 'err'):
-            return timestamp, 'error'
-        elif matched in ('warn', 'warning'):
-            return timestamp, 'warn'
-        elif matched == 'info':
-            return timestamp, 'info'
-        elif matched == 'debug':
-            return timestamp, 'debug'
-        elif matched == 'trace':
-            return timestamp, 'trace'
+        if matched in ("fatal", "panic", "critical"):
+            return timestamp, "fatal"
+        elif matched in ("error", "err"):
+            return timestamp, "error"
+        elif matched in ("warn", "warning"):
+            return timestamp, "warn"
+        elif matched == "info":
+            return timestamp, "info"
+        elif matched == "debug":
+            return timestamp, "debug"
+        elif matched == "trace":
+            return timestamp, "trace"
 
     # Pattern 2: Bracketed log levels: [ERROR], [INFO], [WARN], etc.
-    bracket_match = re.search(r'\[(fatal|panic|critical|error|err|warn|warning|info|debug|trace)\]', line_lower)
+    bracket_match = re.search(
+        r"\[(fatal|panic|critical|error|err|warn|warning|info|debug|trace)\]", line_lower
+    )
     if bracket_match:
         matched = bracket_match.group(1)
-        if matched in ('fatal', 'panic', 'critical'):
-            return timestamp, 'fatal'
-        elif matched in ('error', 'err'):
-            return timestamp, 'error'
-        elif matched in ('warn', 'warning'):
-            return timestamp, 'warn'
-        elif matched == 'info':
-            return timestamp, 'info'
-        elif matched == 'debug':
-            return timestamp, 'debug'
-        elif matched == 'trace':
-            return timestamp, 'trace'
+        if matched in ("fatal", "panic", "critical"):
+            return timestamp, "fatal"
+        elif matched in ("error", "err"):
+            return timestamp, "error"
+        elif matched in ("warn", "warning"):
+            return timestamp, "warn"
+        elif matched == "info":
+            return timestamp, "info"
+        elif matched == "debug":
+            return timestamp, "debug"
+        elif matched == "trace":
+            return timestamp, "trace"
 
     # Pattern 3: Structured log formats: level=error, "level":"error", level: error
-    structured_match = re.search(r'(?:level|lvl|severity)[=:"\s]+["\']?(fatal|panic|critical|error|err|warn|warning|info|debug|trace)["\']?', line_lower)
+    structured_match = re.search(
+        r'(?:level|lvl|severity)[=:"\s]+["\']?(fatal|panic|critical|error|err|warn|warning|info|debug|trace)["\']?',
+        line_lower,
+    )
     if structured_match:
         matched = structured_match.group(1)
-        if matched in ('fatal', 'panic', 'critical'):
-            return timestamp, 'fatal'
-        elif matched in ('error', 'err'):
-            return timestamp, 'error'
-        elif matched in ('warn', 'warning'):
-            return timestamp, 'warn'
-        elif matched == 'info':
-            return timestamp, 'info'
-        elif matched == 'debug':
-            return timestamp, 'debug'
-        elif matched == 'trace':
-            return timestamp, 'trace'
+        if matched in ("fatal", "panic", "critical"):
+            return timestamp, "fatal"
+        elif matched in ("error", "err"):
+            return timestamp, "error"
+        elif matched in ("warn", "warning"):
+            return timestamp, "warn"
+        elif matched == "info":
+            return timestamp, "info"
+        elif matched == "debug":
+            return timestamp, "debug"
+        elif matched == "trace":
+            return timestamp, "trace"
 
     # Pattern 4: Kubernetes-style single letter prefixes: I0124 (info), E0124 (error), W0124 (warn)
-    k8s_match = re.match(r'^([IWEF])\d{4}\s', line)
+    k8s_match = re.match(r"^([IWEF])\d{4}\s", line)
     if k8s_match:
         letter = k8s_match.group(1)
-        if letter == 'I':
-            return timestamp, 'info'
-        elif letter == 'W':
-            return timestamp, 'warn'
-        elif letter == 'E':
-            return timestamp, 'error'
-        elif letter == 'F':
-            return timestamp, 'fatal'
+        if letter == "I":
+            return timestamp, "info"
+        elif letter == "W":
+            return timestamp, "warn"
+        elif letter == "E":
+            return timestamp, "error"
+        elif letter == "F":
+            return timestamp, "fatal"
 
     return timestamp, level
 
 
-def _count_related_entries(lines: List[str], current_index: int, semantic_keywords: List[str]) -> int:
+def _count_related_entries(
+    lines: List[str], current_index: int, semantic_keywords: List[str]
+) -> int:
     """Count related log entries near the current match."""
     count = 0
     search_range = 5  # Look 5 lines before and after
@@ -464,6 +521,7 @@ def _count_related_entries(lines: List[str], current_index: int, semantic_keywor
 # RESULT RANKING AND PROCESSING
 # ============================================================================
 
+
 def _truncate_result_content(result: Dict[str, Any], max_message_len: int = 300) -> Dict[str, Any]:
     """Truncate log message content in a search result to limit output size."""
     result = result.copy()
@@ -480,7 +538,7 @@ def _truncate_result_content(result: Dict[str, Any], max_message_len: int = 300)
 def rank_results_by_semantic_relevance(
     all_results: List[Dict[str, Any]],
     query_interpretation: Dict[str, Any],
-    group_similar: bool = True
+    group_similar: bool = True,
 ) -> List[Dict[str, Any]]:
     """Rank and filter results by semantic relevance."""
     if not all_results:
@@ -493,14 +551,14 @@ def rank_results_by_semantic_relevance(
         # Rank groups by best relevance score
         ranked_groups = sorted(
             grouped_results,
-            key=lambda group: max(item.get('relevance_score', 0) for item in group),
-            reverse=True
+            key=lambda group: max(item.get("relevance_score", 0) for item in group),
+            reverse=True,
         )
 
         # Deduplicate: keep only the best representative from each group
         ranked_results = []
         for group in ranked_groups:
-            best = max(group, key=lambda x: x.get('relevance_score', 0))
+            best = max(group, key=lambda x: x.get("relevance_score", 0))
             best = _truncate_result_content(best)
             if len(group) > 1:
                 best["similar_count"] = len(group) - 1
@@ -509,7 +567,9 @@ def rank_results_by_semantic_relevance(
         return ranked_results
     else:
         # Simple sort by relevance, with truncation
-        sorted_results = sorted(all_results, key=lambda x: x.get('relevance_score', 0), reverse=True)
+        sorted_results = sorted(
+            all_results, key=lambda x: x.get("relevance_score", 0), reverse=True
+        )
         return [_truncate_result_content(r) for r in sorted_results]
 
 
@@ -542,18 +602,20 @@ def _group_similar_results(results: List[Dict[str, Any]]) -> List[List[Dict[str,
 def _get_result_content(result: Dict[str, Any]) -> str:
     """Extract the text content from a search result for comparison."""
     # Check nested log_entry.message first (standard structure from _search_pod_logs_semantically)
-    log_entry = result.get('log_entry', {})
-    if isinstance(log_entry, dict) and log_entry.get('message'):
-        return str(log_entry['message'])
+    log_entry = result.get("log_entry", {})
+    if isinstance(log_entry, dict) and log_entry.get("message"):
+        return str(log_entry["message"])
     # Fall back to top-level content
-    return result.get('content', '')
+    return result.get("content", "")
 
 
 def _get_result_source_key(result: Dict[str, Any]) -> str:
     """Build a comparable string key from a result's source metadata."""
-    source = result.get('source', {})
+    source = result.get("source", {})
     if isinstance(source, dict):
-        return f"{source.get('type', '')}:{source.get('namespace', '')}:{source.get('pod_name', '')}"
+        return (
+            f"{source.get('type', '')}:{source.get('namespace', '')}:{source.get('pod_name', '')}"
+        )
     return str(source)
 
 
@@ -585,6 +647,7 @@ def _are_results_similar(result1: Dict[str, Any], result2: Dict[str, Any]) -> bo
 # PATTERN IDENTIFICATION
 # ============================================================================
 
+
 def identify_common_patterns(ranked_results: List[Dict[str, Any]]) -> List[str]:
     """Identify common patterns across search results."""
     patterns = []
@@ -596,13 +659,13 @@ def identify_common_patterns(ranked_results: List[Dict[str, Any]]) -> List[str]:
     level_counts = defaultdict(int)
     for result in ranked_results:
         # Check nested log_entry.level first, then top-level log_level
-        log_entry = result.get('log_entry', {})
-        level = log_entry.get('level') if isinstance(log_entry, dict) else None
+        log_entry = result.get("log_entry", {})
+        level = log_entry.get("level") if isinstance(log_entry, dict) else None
         if not level:
-            level = result.get('log_level', 'unknown')
+            level = result.get("log_level", "unknown")
         # Normalize level names
-        if level == 'warning':
-            level = 'warn'
+        if level == "warning":
+            level = "warn"
         level_counts[level] += 1
 
     total_results = len(ranked_results)
@@ -614,14 +677,17 @@ def identify_common_patterns(ranked_results: List[Dict[str, Any]]) -> List[str]:
     content_words = []
     for result in ranked_results:
         # Check nested log_entry.message first, then top-level content
-        log_entry = result.get('log_entry', {})
-        content = log_entry.get('message', '') if isinstance(log_entry, dict) else ''
+        log_entry = result.get("log_entry", {})
+        content = log_entry.get("message", "") if isinstance(log_entry, dict) else ""
         if not content:
-            content = result.get('content', '')
+            content = result.get("content", "")
         content = content.lower()
         # Extract meaningful words (excluding common words)
-        words = [word for word in content.split()
-                if len(word) > 3 and word not in ['the', 'and', 'for', 'with', 'from']]
+        words = [
+            word
+            for word in content.split()
+            if len(word) > 3 and word not in ["the", "and", "for", "with", "from"]
+        ]
         content_words.extend(words)
 
     # Find frequent words
@@ -629,8 +695,9 @@ def identify_common_patterns(ranked_results: List[Dict[str, Any]]) -> List[str]:
     for word in content_words:
         word_counts[word] += 1
 
-    frequent_words = [word for word, count in word_counts.items()
-                     if count > len(ranked_results) * 0.25]
+    frequent_words = [
+        word for word, count in word_counts.items() if count > len(ranked_results) * 0.25
+    ]
 
     if frequent_words:
         patterns.append(f"Common terms: {', '.join(frequent_words[:5])}")
@@ -639,11 +706,11 @@ def identify_common_patterns(ranked_results: List[Dict[str, Any]]) -> List[str]:
     timestamps = []
     for result in ranked_results:
         # Check nested log_entry.timestamp first, then top-level timestamp
-        log_entry = result.get('log_entry', {})
-        ts = log_entry.get('timestamp') if isinstance(log_entry, dict) else None
-        if not ts or ts == 'unknown':
-            ts = result.get('timestamp', '')
-        if ts and ts != 'unknown':
+        log_entry = result.get("log_entry", {})
+        ts = log_entry.get("timestamp") if isinstance(log_entry, dict) else None
+        if not ts or ts == "unknown":
+            ts = result.get("timestamp", "")
+        if ts and ts != "unknown":
             timestamps.append(ts)
 
     if len(timestamps) > 5:
@@ -654,23 +721,23 @@ def identify_common_patterns(ranked_results: List[Dict[str, Any]]) -> List[str]:
 
 def analyze_severity_distribution(ranked_results: List[Dict[str, Any]]) -> Dict[str, int]:
     """Analyze severity distribution of search results."""
-    severity_counts = {'error': 0, 'warn': 0, 'info': 0, 'debug': 0, 'unknown': 0}
+    severity_counts = {"error": 0, "warn": 0, "info": 0, "debug": 0, "unknown": 0}
 
     for result in ranked_results:
         # Check nested log_entry.level first, then top-level log_level for backwards compatibility
-        log_entry = result.get('log_entry', {})
-        level = log_entry.get('level') if isinstance(log_entry, dict) else None
+        log_entry = result.get("log_entry", {})
+        level = log_entry.get("level") if isinstance(log_entry, dict) else None
         if not level:
-            level = result.get('log_level', 'unknown')
+            level = result.get("log_level", "unknown")
 
         # Normalize level names (warn/warning -> warn)
-        if level == 'warning':
-            level = 'warn'
+        if level == "warning":
+            level = "warn"
 
         if level in severity_counts:
             severity_counts[level] += 1
         else:
-            severity_counts['unknown'] += 1
+            severity_counts["unknown"] += 1
 
     return severity_counts
 
@@ -679,19 +746,15 @@ def analyze_severity_distribution(ranked_results: List[Dict[str, Any]]) -> Dict[
 # SEARCH SUGGESTIONS
 # ============================================================================
 
+
 def generate_semantic_suggestions(
-    query_interpretation: Dict[str, Any],
-    search_results: List[Dict[str, Any]]
+    query_interpretation: Dict[str, Any], search_results: List[Dict[str, Any]]
 ) -> Dict[str, Any]:
     """Generate search suggestions based on query interpretation and results."""
-    suggestions = {
-        "related_queries": [],
-        "broader_search": "",
-        "narrower_search": ""
-    }
+    suggestions = {"related_queries": [], "broader_search": "", "narrower_search": ""}
 
-    primary_intent = query_interpretation.get('primary_intent', 'general_search')
-    confidence = query_interpretation.get('intent_confidence', 0)
+    primary_intent = query_interpretation.get("primary_intent", "general_search")
+    confidence = query_interpretation.get("intent_confidence", 0)
 
     # Low confidence suggestions
     if confidence < 2:
@@ -699,21 +762,27 @@ def generate_semantic_suggestions(
         suggestions["related_queries"].append("Include error messages or specific component names")
 
     # Intent-specific suggestions
-    if primary_intent == 'error_investigation':
-        suggestions["related_queries"].extend([
-            "Search for 'exception' or 'failed' for more error details",
-            "Try searching for specific error codes or messages"
-        ])
-    elif primary_intent == 'performance_analysis':
-        suggestions["related_queries"].extend([
-            "Search for 'timeout', 'slow', or 'latency' keywords",
-            "Look for memory or CPU related issues"
-        ])
-    elif primary_intent == 'deployment_tracking':
-        suggestions["related_queries"].extend([
-            "Search for 'rollout', 'update', or 'version' keywords",
-            "Look for deployment status messages"
-        ])
+    if primary_intent == "error_investigation":
+        suggestions["related_queries"].extend(
+            [
+                "Search for 'exception' or 'failed' for more error details",
+                "Try searching for specific error codes or messages",
+            ]
+        )
+    elif primary_intent == "performance_analysis":
+        suggestions["related_queries"].extend(
+            [
+                "Search for 'timeout', 'slow', or 'latency' keywords",
+                "Look for memory or CPU related issues",
+            ]
+        )
+    elif primary_intent == "deployment_tracking":
+        suggestions["related_queries"].extend(
+            [
+                "Search for 'rollout', 'update', or 'version' keywords",
+                "Look for deployment status messages",
+            ]
+        )
 
     # Results-based suggestions
     if not search_results:
@@ -733,23 +802,19 @@ def generate_semantic_suggestions(
 # ASYNC SEARCH HELPER FUNCTIONS
 # ============================================================================
 
+
 def _build_log_params(search_params: Dict[str, Any]) -> Dict[str, Any]:
     """Build log retrieval parameters from search params."""
-    time_range = search_params.get('time_range', '1h')
+    time_range = search_params.get("time_range", "1h")
 
     # Convert time range to seconds
-    time_mapping = {
-        '1h': 3600,
-        '6h': 21600,
-        '24h': 86400,
-        '7d': 604800
-    }
+    time_mapping = {"1h": 3600, "6h": 21600, "24h": 86400, "7d": 604800}
 
     since_seconds = time_mapping.get(time_range, 3600)
 
     return {
-        'since_seconds': since_seconds,
-        'tail_lines': 500  # Reasonable limit for semantic analysis
+        "since_seconds": since_seconds,
+        "tail_lines": 500,  # Reasonable limit for semantic analysis
     }
 
 
@@ -757,7 +822,7 @@ async def _get_target_namespaces(
     namespaces: Optional[List[str]],
     identified_components: List[str],
     list_namespaces,
-    detect_tekton_namespaces_func
+    detect_tekton_namespaces_func,
 ) -> List[str]:
     """Determine target namespaces based on provided namespaces and identified components."""
     if namespaces:
@@ -775,7 +840,7 @@ async def _get_target_namespaces(
             target_namespaces.extend(ns_list)
 
         # Add some common system namespaces
-        system_namespaces = ['kube-system', 'openshift-etcd', 'openshift-apiserver']
+        system_namespaces = ["kube-system", "openshift-etcd", "openshift-apiserver"]
         for ns in system_namespaces:
             if ns in all_namespaces:
                 target_namespaces.append(ns)
@@ -784,11 +849,11 @@ async def _get_target_namespaces(
 
     # Component-specific namespace targeting
     component_namespace_hints = {
-        'pipelinerun': ['tekton', 'pipeline', 'ci', 'build'],
-        'taskrun': ['tekton', 'pipeline', 'ci', 'build'],
-        'pod': all_namespaces,  # Pods can be anywhere
-        'deployment': all_namespaces,
-        'service': all_namespaces
+        "pipelinerun": ["tekton", "pipeline", "ci", "build"],
+        "taskrun": ["tekton", "pipeline", "ci", "build"],
+        "pod": all_namespaces,  # Pods can be anywhere
+        "deployment": all_namespaces,
+        "service": all_namespaces,
     }
 
     target_namespaces = set()
@@ -810,25 +875,25 @@ async def _search_pod_logs_semantically(
     search_params: Dict[str, Any],
     get_pod_logs,
     build_log_params_func,
-    find_semantic_matches_func
+    find_semantic_matches_func,
 ) -> List[Dict[str, Any]]:
     """Search pod logs using semantic matching."""
     import logging
 
     logger = logging.getLogger(__name__)
     results = []
-    pod_name = pod_info.get('name', 'unknown')
+    pod_name = pod_info.get("name", "unknown")
 
     try:
         # Get pod logs with time filtering
         log_params = build_log_params_func(search_params)
         pod_logs = await get_pod_logs(namespace, pod_name, **log_params)
 
-        if not pod_logs or 'error' in pod_logs:
+        if not pod_logs or "error" in pod_logs:
             return results
 
         # Logs are keyed by container name, not pod name
-        logs_dict = pod_logs.get('logs', {})
+        logs_dict = pod_logs.get("logs", {})
         if not logs_dict:
             return results
 
@@ -838,7 +903,7 @@ async def _search_pod_logs_semantically(
             if isinstance(container_logs, list):
                 all_logs_lines.extend(container_logs)
             elif isinstance(container_logs, str):
-                all_logs_lines.extend(container_logs.split('\n'))
+                all_logs_lines.extend(container_logs.split("\n"))
 
         if not all_logs_lines:
             return results
@@ -847,37 +912,74 @@ async def _search_pod_logs_semantically(
 
         # Perform semantic matching on logs
         # Extract original query terms (words > 2 chars, excluding stop words)
-        original_query = query_interpretation.get('original_query', '')
-        stop_words = {'the', 'and', 'for', 'are', 'but', 'not', 'you', 'all', 'can', 'had', 'her', 'was', 'one', 'our', 'out', 'has', 'have', 'from', 'with', 'they', 'been', 'that', 'this', 'what', 'which', 'errors', 'logs', 'find', 'show', 'get', 'any', 'pods'}
-        original_terms = [w for w in original_query.lower().split() if len(w) > 2 and w not in stop_words]
+        original_query = query_interpretation.get("original_query", "")
+        stop_words = {
+            "the",
+            "and",
+            "for",
+            "are",
+            "but",
+            "not",
+            "you",
+            "all",
+            "can",
+            "had",
+            "her",
+            "was",
+            "one",
+            "our",
+            "out",
+            "has",
+            "have",
+            "from",
+            "with",
+            "they",
+            "been",
+            "that",
+            "this",
+            "what",
+            "which",
+            "errors",
+            "logs",
+            "find",
+            "show",
+            "get",
+            "any",
+            "pods",
+        }
+        original_terms = [
+            w for w in original_query.lower().split() if len(w) > 2 and w not in stop_words
+        ]
 
         matches = find_semantic_matches_func(
             logs_lines,
-            query_interpretation.get('semantic_keywords', []),
-            query_interpretation.get('primary_intent', 'general_search'),
-            search_params.get('max_results', 50),
-            original_query_terms=original_terms
+            query_interpretation.get("semantic_keywords", []),
+            query_interpretation.get("primary_intent", "general_search"),
+            search_params.get("max_results", 50),
+            original_query_terms=original_terms,
         )
 
         for match in matches:
-            results.append({
-                "source": {
-                    "type": "pod_logs",
-                    "namespace": namespace,
-                    "pod_name": pod_name,
-                    "pod_status": pod_info.get('status', 'unknown'),
-                    "node_name": pod_info.get('node_name', 'unknown')
-                },
-                "log_entry": {
-                    "timestamp": match.get('timestamp', 'unknown'),
-                    "level": match.get('log_level', 'info'),
-                    "message": match.get('content', ''),
-                    "line_number": match.get('line_number', 0)
-                },
-                "relevance_score": match.get('relevance_score', 0),
-                "match_reasons": match.get('match_reasons', []),
-                "related_entries": match.get('related_count', 0)
-            })
+            results.append(
+                {
+                    "source": {
+                        "type": "pod_logs",
+                        "namespace": namespace,
+                        "pod_name": pod_name,
+                        "pod_status": pod_info.get("status", "unknown"),
+                        "node_name": pod_info.get("node_name", "unknown"),
+                    },
+                    "log_entry": {
+                        "timestamp": match.get("timestamp", "unknown"),
+                        "level": match.get("log_level", "info"),
+                        "message": match.get("content", ""),
+                        "line_number": match.get("line_number", 0),
+                    },
+                    "relevance_score": match.get("relevance_score", 0),
+                    "match_reasons": match.get("match_reasons", []),
+                    "related_entries": match.get("related_count", 0),
+                }
+            )
 
     except Exception as e:
         logger.warning(f"Error searching pod logs for {pod_name}: {str(e)}")
@@ -892,7 +994,7 @@ async def _search_events_semantically(
     get_namespace_events_func,
     calc_semantic_relevance_func,
     identify_match_reasons_func,
-    extract_log_metadata_func
+    extract_log_metadata_func,
 ) -> List[Dict[str, Any]]:
     """Search Kubernetes events using semantic matching."""
     import logging
@@ -902,13 +1004,13 @@ async def _search_events_semantically(
 
     try:
         events_response = await get_namespace_events_func(namespace)
-        events = events_response.get('events', [])
+        events = events_response.get("events", [])
 
         if not events:
             return results
 
-        semantic_keywords = query_interpretation.get('semantic_keywords', [])
-        primary_intent = query_interpretation.get('primary_intent', 'general_search')
+        semantic_keywords = query_interpretation.get("semantic_keywords", [])
+        primary_intent = query_interpretation.get("primary_intent", "general_search")
 
         for event_line in events:
             relevance_score = calc_semantic_relevance_func(
@@ -923,21 +1025,20 @@ async def _search_events_semantically(
                 # Parse event details
                 timestamp, level = extract_log_metadata_func(event_line)
 
-                results.append({
-                    "source": {
-                        "type": "kubernetes_events",
-                        "namespace": namespace
-                    },
-                    "log_entry": {
-                        "timestamp": timestamp,
-                        "level": level,
-                        "message": event_line,
-                        "context_lines": []
-                    },
-                    "relevance_score": relevance_score,
-                    "match_reasons": match_reasons,
-                    "related_entries": 0
-                })
+                results.append(
+                    {
+                        "source": {"type": "kubernetes_events", "namespace": namespace},
+                        "log_entry": {
+                            "timestamp": timestamp,
+                            "level": level,
+                            "message": event_line,
+                            "context_lines": [],
+                        },
+                        "relevance_score": relevance_score,
+                        "match_reasons": match_reasons,
+                        "related_entries": 0,
+                    }
+                )
 
     except Exception as e:
         logger.warning(f"Error searching events in namespace {namespace}: {str(e)}")
@@ -950,7 +1051,7 @@ async def _search_tekton_resources_semantically(
     query_interpretation: Dict[str, Any],
     search_params: Dict[str, Any],
     list_pipelineruns,
-    calc_semantic_relevance_func
+    calc_semantic_relevance_func,
 ) -> List[Dict[str, Any]]:
     """Search Tekton resources using semantic matching."""
     import logging
@@ -963,31 +1064,37 @@ async def _search_tekton_resources_semantically(
         pipeline_runs = await list_pipelineruns(namespace)
 
         if pipeline_runs and not isinstance(pipeline_runs, dict):
-            semantic_keywords = query_interpretation.get('semantic_keywords', [])
+            semantic_keywords = query_interpretation.get("semantic_keywords", [])
 
             for pr in pipeline_runs:
                 pr_text = f"{pr.get('name', '')} {pr.get('status', '')} {pr.get('pipeline', '')}"
                 relevance_score = calc_semantic_relevance_func(
-                    pr_text, semantic_keywords, 'pipeline_monitoring'
+                    pr_text, semantic_keywords, "pipeline_monitoring"
                 )
 
                 if relevance_score > 0.3:
-                    results.append({
-                        "source": {
-                            "type": "tekton_pipelinerun",
-                            "namespace": namespace,
-                            "resource_name": pr.get('name', 'unknown')
-                        },
-                        "log_entry": {
-                            "timestamp": pr.get('started_at', 'unknown'),
-                            "level": 'info' if pr.get('status') == 'Succeeded' else 'error',
-                            "message": f"PipelineRun {pr.get('name', 'unknown')} - Status: {pr.get('status', 'unknown')}, Duration: {pr.get('duration', 'unknown')}",
-                            "context_lines": []
-                        },
-                        "relevance_score": relevance_score,
-                        "match_reasons": ["Tekton resource match"],
-                        "related_entries": 0
-                    })
+                    results.append(
+                        {
+                            "source": {
+                                "type": "tekton_pipelinerun",
+                                "namespace": namespace,
+                                "resource_name": pr.get("name", "unknown"),
+                            },
+                            "log_entry": {
+                                "timestamp": pr.get("started_at", "unknown"),
+                                "level": "info" if pr.get("status") == "Succeeded" else "error",
+                                "message": (
+                                    f"PipelineRun {pr.get('name', 'unknown')}"
+                                    f" - Status: {pr.get('status', 'unknown')}"
+                                    f", Duration: {pr.get('duration', 'unknown')}"
+                                ),
+                                "context_lines": [],
+                            },
+                            "relevance_score": relevance_score,
+                            "match_reasons": ["Tekton resource match"],
+                            "related_entries": 0,
+                        }
+                    )
 
     except Exception as e:
         logger.warning(f"Error searching Tekton resources in namespace {namespace}: {str(e)}")


### PR DESCRIPTION
## Motivation

Issue #147 requested documentation for several undocumented subsystems in the Lumino MCP server. The README was missing coverage of ML model persistence, KubeArchive integration, and the Prometheus/Thanos query layer, making it harder for new contributors and operators to understand these capabilities.

## Changes

Added three new sections to the README:

1. **ML Model Persistence** -- documents how trained anomaly-detection models are cached, stored, and reloaded across server restarts, including the file layout and cache invalidation logic.
2. **KubeArchive Integration** -- explains how the server queries KubeArchive for historical Kubernetes resources (PipelineRuns, TaskRuns, pods) whose live objects have been garbage-collected from the cluster.
3. **Prometheus / Thanos Query Layer** -- covers endpoint discovery, authentication, PromQL execution, and how range vs. instant queries are handled.

## Linked Issue

Fixes #147