### PR TITLE
feature:lntegrate LogAn to Lumino mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ An open source MCP (Model Context Protocol) server empowering SREs with intellig
 
 ## Overview
 
-LUMINO MCP Server transforms how Site Reliability Engineers (SREs) and DevOps teams interact with Kubernetes clusters. By exposing 37 specialized tools through the Model Context Protocol, it enables AI assistants to:
+LUMINO MCP Server transforms how Site Reliability Engineers (SREs) and DevOps teams interact with Kubernetes clusters. By exposing 39 specialized tools through the Model Context Protocol, it enables AI assistants to:
 
 - **Monitor** cluster health, resources, and pipeline status in real-time
 - **Analyze** logs, events, and anomalies using statistical and ML techniques
@@ -433,7 +433,7 @@ The server automatically detects Kubernetes configuration:
 | `find_pipeline` | Find pipelines by pattern matching |
 | `get_tekton_pipeline_runs_status` | Cluster-wide pipeline status summary |
 
-### Log Analysis (6 tools)
+### Log Analysis (8 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -443,6 +443,8 @@ The server automatically detects Kubernetes configuration:
 | `analyze_pod_logs_hybrid` | Combined analysis strategies |
 | `detect_log_anomalies` | Anomaly detection with severity levels |
 | `semantic_log_search` | NLP-based semantic log search |
+| `templatize_pod_logs` | Cluster logs into unique structural templates using Drain3 (requires optional `logan` dependency) |
+| `deep_analyze_pod_logs` | Classify log templates into golden signals and fault categories using zero-shot ML (requires optional `logan` dependency) |
 
 
 ### Event Analysis (3 tools)
@@ -517,7 +519,7 @@ The server automatically detects Kubernetes configuration:
 lumino-mcp-server/
 ├── main.py                 # Entry point with transport detection
 ├── src/
-│   ├── server-mcp.py       # MCP server with all 37 tools
+│   ├── server-mcp.py       # MCP server with all 39 tools
 │   └── helpers/
 │       ├── constants.py    # Shared constants
 │       ├── event_analysis.py    # Event processing logic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "networkx>=3.0",
 ]
 [project.optional-dependencies]
-logan=["logan"]
+logan=["logan @ git+https://github.com/Log-Analyzer/LogAn.git"]
 
 [project.urls]
 Homepage = "https://github.com/spre-sre/lumino-mcp-server"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "starlette>=0.30.0",
     "networkx>=3.0",
 ]
+[project.optional-dependencies]
+logan=["logan"]
 
 [project.urls]
 Homepage = "https://github.com/spre-sre/lumino-mcp-server"

--- a/src/server-mcp.py
+++ b/src/server-mcp.py
@@ -8,6 +8,7 @@ for Kubernetes, OpenShift, and Tekton monitoring and analysis.
 import re
 import os
 import json
+import shutil
 import yaml
 import time
 import base64
@@ -15,6 +16,8 @@ import asyncio
 import logging
 import requests
 import aiohttp
+import tempfile
+import shutil
 from datetime import datetime
 from typing import Dict, List, Optional, Any, Union, Callable
 from mcp.server.fastmcp import FastMCP
@@ -12595,3 +12598,223 @@ async def query_kubearchive(
             except Exception:
                 pass
         return out
+
+async def _run_logan_pipeline(namespace,pod_name,container_name,tail_lines,since_seconds,debug_mode="false"):
+
+    """Shared logic for fetch logs,templatize,and return raw objects."""
+    import logan
+    from logan.preprocessing.preprocessing import Preprocessing
+    from logan.drain.run_drain import Templatizer
+
+
+    logs_result=await get_pod_logs(namespace, pod_name, container_name, tail_lines=tail_lines, since_seconds=since_seconds)
+    if logs_result.get("error"):
+        return None,None,None,logs_result
+
+    log_text="\n".join(logs_result["logs"].values())
+    log_lines=log_text.strip().split("\n")
+
+    tmpdir=tempfile.mkdtemp()
+    input_file=os.path.join(tmpdir, "pod_logs.log")
+    with open(input_file, "w") as f:
+        f.write(log_text)
+
+    
+    output_dir=os.path.join(tmpdir, "output")
+    os.makedirs(output_dir)
+    os.makedirs(os.path.join(output_dir, "developer_debug_files"),exist_ok=True)
+    os.makedirs(os.path.join(output_dir, "metrics"),exist_ok=True)
+
+    os.environ["LOGAN_DISABLE_PANDARALLEL"]="1"
+    os.environ["TOKENIZERS_PARALLELISM"]="false"
+
+    pp=Preprocessing(debug_mode=debug_mode)
+    pp.preprocess([input_file],"all-data",output_dir,False,True,False)
+
+    drain_config=os.path.join(os.path.dirname(logan.__file__), "drain", "drain3.ini")
+
+    templatizer=Templatizer(debug_mode=debug_mode,config_path=drain_config)
+    templatizer.miner(pp.df,output_dir)
+
+    return templatizer.df,output_dir,tmpdir,None
+
+@mcp.tool()
+async def templatize_pod_logs(
+    namespace: str,
+    pod_name: str,
+    container_name: Optional[str]=None,
+    tail_lines: int=5000,
+    since_seconds: Optional[int]=None,
+    debug_mode: str="false",
+)-> Dict[str,Any]:
+    
+    """Cluster pod logs into unique structural templates using Drain3 parse-tree mining.
+
+    Unlike analyze_logs or analyze_pod_logs_hybrid which scan each line individually
+    with regex, this tool groups thousands of repetitive log lines into a handful of
+    distinct patterns (e.g. 10,000 lines → 25 templates). Use this when:
+    - Logs are high-volume and noisy — the user needs to see the forest, not every tree
+    - The user asks to "summarize", "deduplicate", "find patterns", or "reduce" logs
+    - You need to know WHAT kinds of log lines exist and HOW MANY of each, not just errors
+
+    Do NOT use this for quick error scanning — the existing analyze_logs tool is faster
+    for that. Use this when volume reduction and pattern discovery matter.
+
+    Args:
+        namespace: Kubernetes namespace of the pod.
+        pod_name: Name of the pod whose logs to templatize.
+        container_name: Specific container (if the pod has multiple).
+        tail_lines: Number of recent log lines to fetch (default 5000).
+        since_seconds: Only fetch logs newer than this many seconds.
+        debug_mode: "true" to write extra debug artifacts, "false" (default) for lean output.
+
+    Returns:
+        Dict with unique templates sorted by frequency, each with a sample log line.
+        Requires the optional 'logan' dependency — returns a clear error if not installed.
+    """
+    tmpdir=None
+    try:
+        df,output_dir,tmpdir,error= await _run_logan_pipeline(namespace, pod_name, container_name, tail_lines=tail_lines, since_seconds=since_seconds,debug_mode=debug_mode)
+        if error:   
+            return {
+                "status": "error",
+                "error": error,
+                "message": "Failed to templatize pod logs",
+            }
+
+        groups=df.groupby("test_ids").agg(
+            template=("template_str","first"),
+            count=("test_ids","count"),
+            sample=("text","first"),
+        ).reset_index().sort_values(by="count",ascending=False)
+
+        return {
+            "status": "success",
+            "pod":f"{namespace}/{pod_name}",
+            "total_unique_templates": len(groups),
+            "templates": [
+                {
+                    "template_id": str(row["test_ids"]),
+                    "template_str": row["template"],
+                    "occurences": int(row["count"]),
+                    "sample":str(row["sample"])[:200],
+                } for _, row in groups.iterrows()
+                ]
+        }
+    except ImportError as e:
+        return {"status": "error", "error": str(e), "message": "LogAn dependencies not installed"}
+    except Exception as e:
+        return {"status": "error", "error": str(e), "message": str(e)}
+    finally:
+        if tmpdir:
+            shutil.rmtree(tmpdir,ignore_errors=True)
+
+@mcp.tool()
+async def deep_analyze_pod_logs(
+    namespace: str,
+    pod_name: str,
+    container_name: Optional[str]=None,
+    tail_lines: int=5000,
+    since_seconds: Optional[int]=None,
+    debug_mode: str="true",
+)-> Dict[str,Any]:
+    """Classify pod logs into golden signals and fault categories using ML (zero-shot transformer).
+
+    Goes beyond regex error scanning: first clusters logs into templates (Drain3), then
+    classifies each template into a golden signal (Error, Latency, Saturation, Availability,
+    Traffic, Info) and fault category (io, authentication, network, application, device)
+    using a cross-encoder BART model. Use this when:
+    - The user asks for root-cause hints, anomaly classification, or "what's wrong"
+    - You need to distinguish between TYPES of problems (network vs auth vs saturation)
+    - The user wants a golden-signal breakdown of pod health, not just an error list
+    - analyze_logs found errors but the user needs deeper categorization of those errors
+
+    Do NOT use this for quick error checks — it loads an ML model on first call (~30-60s).
+    Prefer analyze_logs or analyze_pod_logs_hybrid for fast, lightweight scanning.
+
+    Args:
+        namespace: Kubernetes namespace of the pod.
+        pod_name: Name of the pod to analyze.
+        container_name: Specific container (if the pod has multiple).
+        tail_lines: Number of recent log lines to fetch (default 5000).
+        since_seconds: Only fetch logs newer than this many seconds.
+        debug_mode: "true" (default) to generate signal map artifacts needed for classification.
+
+    Returns:
+        Dict with golden_signal_distribution (signal → count) and per-template results
+        including golden signal, fault category, occurrence count, and sample log line.
+        Requires the optional 'logan' dependency — returns a clear error if not installed.
+    """
+
+    from logan.log_diagnosis.anomaly import Anomaly
+    from logan.log_diagnosis.models import ModelManager, ModelType
+    from logan.log_diagnosis.models.model_zero_shot_classifer import ZeroShotModels
+
+    tmpdir=None
+    try:
+        df,output_dir,tmpdir,error= await _run_logan_pipeline(namespace, pod_name, container_name, tail_lines=tail_lines, since_seconds=since_seconds,debug_mode=debug_mode)
+
+        if error:
+            return {
+                "status": "error",
+                "error": error,
+                "message": "Failed to deep analyze pod logs",
+            }
+
+        model_enum=ZeroShotModels.CROSSENCODER
+        model_mgr=ModelManager(ModelType.ZERO_SHOT,model_enum)
+
+        anomaly=object.__new__(Anomaly)
+        anomaly.debug_mode="true"
+        anomaly.model_manager=model_mgr
+
+        anomaly_report=anomaly.get_anomaly_report(df,output_dir)
+        signal_map_path=os.path.join(output_dir, "developer_debug_files","temp_id_to_signal_map.json")
+
+        signal_map={}
+        if os.path.exists(signal_map_path):
+            with open(signal_map_path, "r") as f:
+                signal_map=json.load(f)
+
+        gs_distribution={}
+        results=[]
+
+        counts= df.groupby(["test_ids","file_names"]).agg(
+            log_lines=("text","first"),
+            occurrences=("text","size"),
+        ).reset_index()
+
+        for _,row in counts.iterrows():
+            t_id=str(row["test_ids"])
+            f_name=str(row["file_names"])
+            key=str((t_id,f_name))  
+            gs,fault=signal_map.get(key,["Info",["other"]])
+
+            gs_distribution[gs]=gs_distribution.get(gs,0)+int(row["occurrences"])
+
+            results.append({
+                    "template_id": t_id,
+                "file_name": f_name,
+                "log_lines": str(row["log_lines"])[:200],
+                "occurrences": int(row["occurrences"]),
+                "gs": gs,
+                "fault": fault[0] if isinstance(fault,list) and fault else fault,
+            })
+
+        results.sort(key=lambda x: x["occurrences"],reverse=True)
+        return {
+            "status": "success",
+            "pod":f"{namespace}/{pod_name}",
+            "total_log_lines":len(df),
+            "total_unique_templates": df["test_ids"].nunique(),
+            "golden_signal_distribution": gs_distribution,
+            "results": results,
+        }
+
+    except ImportError as e:
+        return {"status": "error", "error": str(e), "message": "LogAn dependencies not installed"}
+    except Exception as e:
+        return {"status": "error", "error": str(e), "message": str(e)}
+    finally:
+        if tmpdir:
+            shutil.rmtree(tmpdir,ignore_errors=True)

--- a/src/server-mcp.py
+++ b/src/server-mcp.py
@@ -8,7 +8,6 @@ for Kubernetes, OpenShift, and Tekton monitoring and analysis.
 import re
 import os
 import json
-import shutil
 import yaml
 import time
 import base64

--- a/src/server-mcp.py
+++ b/src/server-mcp.py
@@ -12598,222 +12598,221 @@ async def query_kubearchive(
                 pass
         return out
 
-async def _run_logan_pipeline(namespace,pod_name,container_name,tail_lines,since_seconds,debug_mode="false"):
-
-    """Shared logic for fetch logs,templatize,and return raw objects."""
+try:
     import logan
-    from logan.preprocessing.preprocessing import Preprocessing
-    from logan.drain.run_drain import Templatizer
+    _LOGAN_AVAILABLE = True
+except ImportError:
+    _LOGAN_AVAILABLE = False
+
+if _LOGAN_AVAILABLE:
+
+    async def _run_logan_pipeline(namespace,pod_name,container_name,tail_lines,since_seconds,debug_mode="false"):
+
+        """Shared logic for fetch logs,templatize,and return raw objects."""
+        from logan.preprocessing.preprocessing import Preprocessing
+        from logan.drain.run_drain import Templatizer
 
 
-    logs_result=await get_pod_logs(namespace, pod_name, container_name, tail_lines=tail_lines, since_seconds=since_seconds)
-    if logs_result.get("error"):
-        return None,None,None,logs_result
+        logs_result=await get_pod_logs(namespace, pod_name, container_name, tail_lines=tail_lines, since_seconds=since_seconds)
+        if logs_result.get("error"):
+            return None,None,None,logs_result
 
-    log_text="\n".join(logs_result["logs"].values())
-    log_lines=log_text.strip().split("\n")
+        log_text="\n".join(logs_result["logs"].values())
+        log_lines=log_text.strip().split("\n")
 
-    tmpdir=tempfile.mkdtemp()
-    input_file=os.path.join(tmpdir, "pod_logs.log")
-    with open(input_file, "w") as f:
-        f.write(log_text)
+        tmpdir=tempfile.mkdtemp()
+        input_file=os.path.join(tmpdir, "pod_logs.log")
+        with open(input_file, "w") as f:
+            f.write(log_text)
 
-    
-    output_dir=os.path.join(tmpdir, "output")
-    os.makedirs(output_dir)
-    os.makedirs(os.path.join(output_dir, "developer_debug_files"),exist_ok=True)
-    os.makedirs(os.path.join(output_dir, "metrics"),exist_ok=True)
 
-    os.environ["LOGAN_DISABLE_PANDARALLEL"]="1"
-    os.environ["TOKENIZERS_PARALLELISM"]="false"
+        output_dir=os.path.join(tmpdir, "output")
+        os.makedirs(output_dir)
+        os.makedirs(os.path.join(output_dir, "developer_debug_files"),exist_ok=True)
+        os.makedirs(os.path.join(output_dir, "metrics"),exist_ok=True)
 
-    pp=Preprocessing(debug_mode=debug_mode)
-    pp.preprocess([input_file],"all-data",output_dir,False,True,False)
+        os.environ["LOGAN_DISABLE_PANDARALLEL"]="1"
+        os.environ["TOKENIZERS_PARALLELISM"]="false"
 
-    drain_config=os.path.join(os.path.dirname(logan.__file__), "drain", "drain3.ini")
+        pp=Preprocessing(debug_mode=debug_mode)
+        pp.preprocess([input_file],"all-data",output_dir,False,True,False)
 
-    templatizer=Templatizer(debug_mode=debug_mode,config_path=drain_config)
-    templatizer.miner(pp.df,output_dir)
+        drain_config=os.path.join(os.path.dirname(logan.__file__), "drain", "drain3.ini")
 
-    return templatizer.df,output_dir,tmpdir,None
+        templatizer=Templatizer(debug_mode=debug_mode,config_path=drain_config)
+        templatizer.miner(pp.df,output_dir)
 
-@mcp.tool()
-async def templatize_pod_logs(
-    namespace: str,
-    pod_name: str,
-    container_name: Optional[str]=None,
-    tail_lines: int=5000,
-    since_seconds: Optional[int]=None,
-    debug_mode: str="false",
-)-> Dict[str,Any]:
-    
-    """Cluster pod logs into unique structural templates using Drain3 parse-tree mining.
+        return templatizer.df,output_dir,tmpdir,None
 
-    Unlike analyze_logs or analyze_pod_logs_hybrid which scan each line individually
-    with regex, this tool groups thousands of repetitive log lines into a handful of
-    distinct patterns (e.g. 10,000 lines → 25 templates). Use this when:
-    - Logs are high-volume and noisy — the user needs to see the forest, not every tree
-    - The user asks to "summarize", "deduplicate", "find patterns", or "reduce" logs
-    - You need to know WHAT kinds of log lines exist and HOW MANY of each, not just errors
+    @mcp.tool()
+    async def templatize_pod_logs(
+        namespace: str,
+        pod_name: str,
+        container_name: Optional[str]=None,
+        tail_lines: int=5000,
+        since_seconds: Optional[int]=None,
+        debug_mode: str="false",
+    )-> Dict[str,Any]:
+        """Cluster pod logs into unique structural templates using Drain3 parse-tree mining.
 
-    Do NOT use this for quick error scanning — the existing analyze_logs tool is faster
-    for that. Use this when volume reduction and pattern discovery matter.
+        Unlike analyze_logs or analyze_pod_logs_hybrid which scan each line individually
+        with regex, this tool groups thousands of repetitive log lines into a handful of
+        distinct patterns (e.g. 10,000 lines → 25 templates). Use this when:
+        - Logs are high-volume and noisy — the user needs to see the forest, not every tree
+        - The user asks to "summarize", "deduplicate", "find patterns", or "reduce" logs
+        - You need to know WHAT kinds of log lines exist and HOW MANY of each, not just errors
 
-    Args:
-        namespace: Kubernetes namespace of the pod.
-        pod_name: Name of the pod whose logs to templatize.
-        container_name: Specific container (if the pod has multiple).
-        tail_lines: Number of recent log lines to fetch (default 5000).
-        since_seconds: Only fetch logs newer than this many seconds.
-        debug_mode: "true" to write extra debug artifacts, "false" (default) for lean output.
+        Do NOT use this for quick error scanning — the existing analyze_logs tool is faster
+        for that. Use this when volume reduction and pattern discovery matter.
 
-    Returns:
-        Dict with unique templates sorted by frequency, each with a sample log line.
-        Requires the optional 'logan' dependency — returns a clear error if not installed.
-    """
-    tmpdir=None
-    try:
-        df,output_dir,tmpdir,error= await _run_logan_pipeline(namespace, pod_name, container_name, tail_lines=tail_lines, since_seconds=since_seconds,debug_mode=debug_mode)
-        if error:   
+        Args:
+            namespace: Kubernetes namespace of the pod.
+            pod_name: Name of the pod whose logs to templatize.
+            container_name: Specific container (if the pod has multiple).
+            tail_lines: Number of recent log lines to fetch (default 5000).
+            since_seconds: Only fetch logs newer than this many seconds.
+            debug_mode: "true" to write extra debug artifacts, "false" (default) for lean output.
+
+        Returns:
+            Dict with unique templates sorted by frequency, each with a sample log line.
+        """
+        tmpdir=None
+        try:
+            df,output_dir,tmpdir,error= await _run_logan_pipeline(namespace, pod_name, container_name, tail_lines=tail_lines, since_seconds=since_seconds,debug_mode=debug_mode)
+            if error:
+                return {
+                    "status": "error",
+                    "error": error,
+                    "message": "Failed to templatize pod logs",
+                }
+
+            groups=df.groupby("test_ids").agg(
+                template=("template_str","first"),
+                count=("test_ids","count"),
+                sample=("text","first"),
+            ).reset_index().sort_values(by="count",ascending=False)
+
             return {
-                "status": "error",
-                "error": error,
-                "message": "Failed to templatize pod logs",
-            }
-
-        groups=df.groupby("test_ids").agg(
-            template=("template_str","first"),
-            count=("test_ids","count"),
-            sample=("text","first"),
-        ).reset_index().sort_values(by="count",ascending=False)
-
-        return {
-            "status": "success",
-            "pod":f"{namespace}/{pod_name}",
-            "total_unique_templates": len(groups),
-            "templates": [
-                {
-                    "template_id": str(row["test_ids"]),
-                    "template_str": row["template"],
-                    "occurences": int(row["count"]),
-                    "sample":str(row["sample"])[:200],
-                } for _, row in groups.iterrows()
+                "status": "success",
+                "pod":f"{namespace}/{pod_name}",
+                "total_unique_templates": len(groups),
+                "templates": [
+                    {
+                        "template_id": str(row["test_ids"]),
+                        "template_str": row["template"],
+                        "occurences": int(row["count"]),
+                        "sample":str(row["sample"])[:200],
+                    } for _, row in groups.iterrows()
                 ]
-        }
-    except ImportError as e:
-        return {"status": "error", "error": str(e), "message": "LogAn dependencies not installed"}
-    except Exception as e:
-        return {"status": "error", "error": str(e), "message": str(e)}
-    finally:
-        if tmpdir:
-            shutil.rmtree(tmpdir,ignore_errors=True)
+            }
+        except Exception as e:
+            return {"status": "error", "error": str(e), "message": str(e)}
+        finally:
+            if tmpdir:
+                shutil.rmtree(tmpdir,ignore_errors=True)
 
-@mcp.tool()
-async def deep_analyze_pod_logs(
-    namespace: str,
-    pod_name: str,
-    container_name: Optional[str]=None,
-    tail_lines: int=5000,
-    since_seconds: Optional[int]=None,
-    debug_mode: str="true",
-)-> Dict[str,Any]:
-    """Classify pod logs into golden signals and fault categories using ML (zero-shot transformer).
+    @mcp.tool()
+    async def deep_analyze_pod_logs(
+        namespace: str,
+        pod_name: str,
+        container_name: Optional[str]=None,
+        tail_lines: int=5000,
+        since_seconds: Optional[int]=None,
+        debug_mode: str="true",
+    )-> Dict[str,Any]:
+        """Classify pod logs into golden signals and fault categories using ML (zero-shot transformer).
 
-    Goes beyond regex error scanning: first clusters logs into templates (Drain3), then
-    classifies each template into a golden signal (Error, Latency, Saturation, Availability,
-    Traffic, Info) and fault category (io, authentication, network, application, device)
-    using a cross-encoder BART model. Use this when:
-    - The user asks for root-cause hints, anomaly classification, or "what's wrong"
-    - You need to distinguish between TYPES of problems (network vs auth vs saturation)
-    - The user wants a golden-signal breakdown of pod health, not just an error list
-    - analyze_logs found errors but the user needs deeper categorization of those errors
+        Goes beyond regex error scanning: first clusters logs into templates (Drain3), then
+        classifies each template into a golden signal (Error, Latency, Saturation, Availability,
+        Traffic, Info) and fault category (io, authentication, network, application, device)
+        using a cross-encoder BART model. Use this when:
+        - The user asks for root-cause hints, anomaly classification, or "what's wrong"
+        - You need to distinguish between TYPES of problems (network vs auth vs saturation)
+        - The user wants a golden-signal breakdown of pod health, not just an error list
+        - analyze_logs found errors but the user needs deeper categorization of those errors
 
-    Do NOT use this for quick error checks — it loads an ML model on first call (~30-60s).
-    Prefer analyze_logs or analyze_pod_logs_hybrid for fast, lightweight scanning.
+        Do NOT use this for quick error checks — it loads an ML model on first call (~30-60s).
+        Prefer analyze_logs or analyze_pod_logs_hybrid for fast, lightweight scanning.
 
-    Args:
-        namespace: Kubernetes namespace of the pod.
-        pod_name: Name of the pod to analyze.
-        container_name: Specific container (if the pod has multiple).
-        tail_lines: Number of recent log lines to fetch (default 5000).
-        since_seconds: Only fetch logs newer than this many seconds.
-        debug_mode: "true" (default) to generate signal map artifacts needed for classification.
+        Args:
+            namespace: Kubernetes namespace of the pod.
+            pod_name: Name of the pod to analyze.
+            container_name: Specific container (if the pod has multiple).
+            tail_lines: Number of recent log lines to fetch (default 5000).
+            since_seconds: Only fetch logs newer than this many seconds.
+            debug_mode: "true" (default) to generate signal map artifacts needed for classification.
 
-    Returns:
-        Dict with golden_signal_distribution (signal → count) and per-template results
-        including golden signal, fault category, occurrence count, and sample log line.
-        Requires the optional 'logan' dependency — returns a clear error if not installed.
-    """
+        Returns:
+            Dict with golden_signal_distribution (signal → count) and per-template results
+            including golden signal, fault category, occurrence count, and sample log line.
+        """
+        from logan.log_diagnosis.anomaly import Anomaly
+        from logan.log_diagnosis.models import ModelManager, ModelType
+        from logan.log_diagnosis.models.model_zero_shot_classifer import ZeroShotModels
 
-    from logan.log_diagnosis.anomaly import Anomaly
-    from logan.log_diagnosis.models import ModelManager, ModelType
-    from logan.log_diagnosis.models.model_zero_shot_classifer import ZeroShotModels
+        tmpdir=None
+        try:
+            df,output_dir,tmpdir,error= await _run_logan_pipeline(namespace, pod_name, container_name, tail_lines=tail_lines, since_seconds=since_seconds,debug_mode=debug_mode)
 
-    tmpdir=None
-    try:
-        df,output_dir,tmpdir,error= await _run_logan_pipeline(namespace, pod_name, container_name, tail_lines=tail_lines, since_seconds=since_seconds,debug_mode=debug_mode)
+            if error:
+                return {
+                    "status": "error",
+                    "error": error,
+                    "message": "Failed to deep analyze pod logs",
+                }
 
-        if error:
+            model_enum=ZeroShotModels.CROSSENCODER
+            model_mgr=ModelManager(ModelType.ZERO_SHOT,model_enum)
+
+            anomaly=object.__new__(Anomaly)
+            anomaly.debug_mode="true"
+            anomaly.model_manager=model_mgr
+
+            anomaly_report=anomaly.get_anomaly_report(df,output_dir)
+            signal_map_path=os.path.join(output_dir, "developer_debug_files","temp_id_to_signal_map.json")
+
+            signal_map={}
+            if os.path.exists(signal_map_path):
+                with open(signal_map_path, "r") as f:
+                    signal_map=json.load(f)
+
+            gs_distribution={}
+            results=[]
+
+            counts= df.groupby(["test_ids","file_names"]).agg(
+                log_lines=("text","first"),
+                occurrences=("text","size"),
+            ).reset_index()
+
+            for _,row in counts.iterrows():
+                t_id=str(row["test_ids"])
+                f_name=str(row["file_names"])
+                key=str((t_id,f_name))
+                gs,fault=signal_map.get(key,["Info",["other"]])
+
+                gs_distribution[gs]=gs_distribution.get(gs,0)+int(row["occurrences"])
+
+                results.append({
+                    "template_id": t_id,
+                    "file_name": f_name,
+                    "log_lines": str(row["log_lines"])[:200],
+                    "occurrences": int(row["occurrences"]),
+                    "gs": gs,
+                    "fault": fault[0] if isinstance(fault,list) and fault else fault,
+                })
+
+            results.sort(key=lambda x: x["occurrences"],reverse=True)
             return {
-                "status": "error",
-                "error": error,
-                "message": "Failed to deep analyze pod logs",
+                "status": "success",
+                "pod":f"{namespace}/{pod_name}",
+                "total_log_lines":len(df),
+                "total_unique_templates": df["test_ids"].nunique(),
+                "golden_signal_distribution": gs_distribution,
+                "results": results,
             }
 
-        model_enum=ZeroShotModels.CROSSENCODER
-        model_mgr=ModelManager(ModelType.ZERO_SHOT,model_enum)
-
-        anomaly=object.__new__(Anomaly)
-        anomaly.debug_mode="true"
-        anomaly.model_manager=model_mgr
-
-        anomaly_report=anomaly.get_anomaly_report(df,output_dir)
-        signal_map_path=os.path.join(output_dir, "developer_debug_files","temp_id_to_signal_map.json")
-
-        signal_map={}
-        if os.path.exists(signal_map_path):
-            with open(signal_map_path, "r") as f:
-                signal_map=json.load(f)
-
-        gs_distribution={}
-        results=[]
-
-        counts= df.groupby(["test_ids","file_names"]).agg(
-            log_lines=("text","first"),
-            occurrences=("text","size"),
-        ).reset_index()
-
-        for _,row in counts.iterrows():
-            t_id=str(row["test_ids"])
-            f_name=str(row["file_names"])
-            key=str((t_id,f_name))  
-            gs,fault=signal_map.get(key,["Info",["other"]])
-
-            gs_distribution[gs]=gs_distribution.get(gs,0)+int(row["occurrences"])
-
-            results.append({
-                    "template_id": t_id,
-                "file_name": f_name,
-                "log_lines": str(row["log_lines"])[:200],
-                "occurrences": int(row["occurrences"]),
-                "gs": gs,
-                "fault": fault[0] if isinstance(fault,list) and fault else fault,
-            })
-
-        results.sort(key=lambda x: x["occurrences"],reverse=True)
-        return {
-            "status": "success",
-            "pod":f"{namespace}/{pod_name}",
-            "total_log_lines":len(df),
-            "total_unique_templates": df["test_ids"].nunique(),
-            "golden_signal_distribution": gs_distribution,
-            "results": results,
-        }
-
-    except ImportError as e:
-        return {"status": "error", "error": str(e), "message": "LogAn dependencies not installed"}
-    except Exception as e:
-        return {"status": "error", "error": str(e), "message": str(e)}
-    finally:
-        if tmpdir:
-            shutil.rmtree(tmpdir,ignore_errors=True)
+        except Exception as e:
+            return {"status": "error", "error": str(e), "message": str(e)}
+        finally:
+            if tmpdir:
+                shutil.rmtree(tmpdir,ignore_errors=True)


### PR DESCRIPTION
## Summary

Add LogAn-based log analysis integration with two new MCP tools:

- **templatize_pod_logs** — clusters pod logs into Drain3 templates (high-volume dedupe).  
- **deep_analyze_pod_logs** — clusters + zero-shot classification into golden signals and fault categories.

Also:

- Add a small shared helper `_run_logan_pipeline` to fetch logs, preprocess, and run the Drain3 pipeline.  
- Add optional dependency declaration for `logan` and document the new tools in README.

These tools are optional (controlled by an optional dependency) and return a clear error if `logan` is not installed.

---

## Type of Change

- [x] New feature (non-breaking change that adds functionality)  
- [x] New MCP tool (adds a new tool to the server)  
- [x] Documentation update  
- [ ] Bug fix (non-breaking change that fixes an issue)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Refactoring (no functional changes)

---

## Changes Made

- **README.md**
  - Updated tool counts and added entries for `templatize_pod_logs` and `deep_analyze_pod_logs`.  
- **pyproject.toml**
  - Added optional dependency group `logan = ["logan"]`.  
- **src/server-mcp.py**
  - Added imports (`tempfile`, `shutil`) and helper function `_run_logan_pipeline`.  
  - Added two new MCP tools:
    - `templatize_pod_logs(namespace, pod_name, container_name=None, tail_lines=5000, since_seconds=None, debug_mode="false")`  
    - `deep_analyze_pod_logs(namespace, pod_name, container_name=None, tail_lines=5000, since_seconds=None, debug_mode="true")`  
  - Both tools handle `ImportError` and return a clear error message if `logan` is absent.  
- No new tests were added in this PR.

---

## New MCP Tool Checklist (per Spec-Driven Development)

- [x] Stage 1: Functional Specification created and reviewed — CREATED LOCALLY (not pushed in this PR). 
- [x] Stage 2: Implementation Specification created and reviewed — CREATED LOCALLY (not pushed in this PR).
- [x] Stage 3: Code follows the implementation spec — Implementation added (see `src/server-mcp.py`).  
- [x] Tool is read-only (no cluster modifications) — tools only fetch and analyze logs.  
- [x] Tool has comprehensive docstring with Args and Returns — docstrings included in the new functions.  
- [x] Tool handles exceptions gracefully — `ImportError` and exceptions caught and returned as structured errors.  
- [x] Tool added to README.md tool list — updated in README (entry present).  
- [ ] Tool added to README tool list documentation (examples/usage) — consider adding a short usage example.

---

## Testing

Manual test steps:

1. Optional dependency (for full functionality):  
   pip install logan
2. Run the server locally:  
   uv run python main.py
3. Call the new tools (via your MCP client or a test script). Example (pseudo):  
   - `templatize_pod_logs("default", "my-pod", container_name=None, tail_lines=2000)`  
   - `deep_analyze_pod_logs("default", "my-pod", container_name=None, tail_lines=2000)`
4. Expected behavior:  
   - If `logan` is installed: tools return `status: "success"` with templates / results.  
   - If `logan` is NOT installed: tools return a structured error indicating missing dependency.

---

## Checklist

- [x] My code follows the project's code style (formatting hints applied where needed; run `ruff` if maintainers ask)  
- [x] I have performed a self-review of my code  
- [x] I have commented my code where necessary (docstrings present)  
- [x] I have updated the documentation accordingly (README entries added)  
- [ ] My changes generate no new warnings (please run CI)  
- [ ] Any dependent changes have been merged

---

## Additional Notes / Review Guidance (important for reviewers)

- **Optional dependency**:  
  - This PR adds `logan` as an optional dependency in `pyproject.toml`. The code imports `logan` at runtime and returns a clear error if the package is absent — nothing breaks for users who don't install it.
- **Runtime / performance considerations**:  
  - `deep_analyze_pod_logs` loads a zero-shot model on first call (the code notes ~30–60s first-call overhead). This is expected; recommend runtime environment with model caching if used in production.  
  - Both tools create a temporary working directory (cleaned up in `finally`). Please confirm cleanup policy in your runtime (containers should allow tmpdir creation).