### PR TITLE
fix: secure model deserialization with HMAC verification (closes #58)

### DIFF
--- a/src/helpers/ml_persistence.py
+++ b/src/helpers/ml_persistence.py
@@ -8,10 +8,14 @@
 # predictive_log_analyzer tool.
 # ============================================================================
 
+import io
 import json
 import hashlib
-import sqlite3
+import hmac as hmac_mod
 import logging
+import os
+import re
+import sqlite3
 from pathlib import Path
 from datetime import datetime, timedelta
 from typing import Dict, List, Any, Optional, Tuple
@@ -95,6 +99,182 @@ class ModelPersistenceManager:
                 "last_cleanup": datetime.now().isoformat()
             })
 
+    # ---- Security: model ID validation and integrity verification ----------
+
+    # Valid model ID pattern: starts with alphanumeric, then alphanumeric/dot/hyphen/underscore
+    _MODEL_ID_PATTERN = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]*$')
+    _SIGNING_KEY_FILE = '.model_signing_key'
+
+    def _validate_model_id(self, model_id: str) -> None:
+        """Validate model_id to prevent path traversal and injection attacks.
+
+        Args:
+            model_id: The model identifier to validate
+
+        Raises:
+            ValueError: If model_id contains unsafe characters or patterns
+        """
+        if not model_id:
+            raise ValueError('model_id cannot be empty')
+        if len(model_id) > 255:
+            raise ValueError('model_id too long (max 255 characters)')
+        if not self._MODEL_ID_PATTERN.match(model_id):
+            raise ValueError(
+                f"Invalid model_id '{model_id}': must start with an alphanumeric "
+                'character and contain only alphanumeric characters, dots, '
+                'hyphens, and underscores'
+            )
+        # Resolve the path and verify it stays within the storage directory
+        resolved_storage = self.storage_dir.resolve()
+        model_path = (self.storage_dir / f'{model_id}.joblib').resolve()
+        if (
+            not str(model_path).startswith(str(resolved_storage) + os.sep)
+            and model_path.parent != resolved_storage
+        ):
+            raise ValueError(
+                f"model_id '{model_id}' resolves outside storage directory"
+            )
+
+    def _get_signing_key(self) -> bytes:
+        """Get or create the model signing key for HMAC verification.
+
+        The key is stored in the parent of the models directory
+        (~/.lumino/.model_signing_key) so that an attacker with write access
+        to the models/ directory alone cannot read the key and forge valid
+        HMACs.
+
+        Returns:
+            The 256-bit signing key
+
+        Raises:
+            ValueError: If the key file exists but is not exactly 32 bytes
+                (corrupted or truncated key)
+        """
+        import tempfile
+
+        key_dir = Path.home() / '.lumino'
+        key_dir.mkdir(parents=True, exist_ok=True)
+        key_file = key_dir / self._SIGNING_KEY_FILE
+
+        # Try to atomically create the key file (O_CREAT|O_EXCL prevents a
+        # TOCTOU race where two concurrent processes both generate different
+        # keys and the last writer silently wins).
+        key = os.urandom(32)
+        try:
+            # Write to a temp file in the same directory first, then
+            # atomically rename to the final path.  This prevents a
+            # half-written key file from being read if os.write() is
+            # interrupted.
+            fd, tmp_path = tempfile.mkstemp(dir=str(key_dir), prefix='.key_tmp_')
+            try:
+                os.write(fd, key)
+            finally:
+                os.close(fd)
+            os.chmod(tmp_path, 0o600)
+
+            # Atomic rename -- if the target already exists on POSIX, the
+            # rename is still atomic but another process won.  Use the
+            # link+unlink trick to emulate O_EXCL semantics for the final
+            # path.
+            try:
+                os.link(tmp_path, str(key_file))
+                os.unlink(tmp_path)
+            except (FileExistsError, OSError):
+                # Another process (or a previous run) already created the
+                # key file.  Discard ours and read theirs.
+                os.unlink(tmp_path)
+                existing_key = key_file.read_bytes()
+                if len(existing_key) != 32:
+                    raise ValueError(
+                        f'Model signing key at {key_file} is corrupted '
+                        f'({len(existing_key)} bytes, expected 32). '
+                        'Delete the file and retry to generate a new key.'
+                    )
+                return existing_key
+
+        except Exception:
+            # If we get here unexpectedly, ensure we still try to read an
+            # existing key file before giving up.
+            if key_file.exists():
+                existing_key = key_file.read_bytes()
+                if len(existing_key) != 32:
+                    raise ValueError(
+                        f'Model signing key at {key_file} is corrupted '
+                        f'({len(existing_key)} bytes, expected 32). '
+                        'Delete the file and retry to generate a new key.'
+                    )
+                return existing_key
+            raise
+
+        # Validate the key we just wrote
+        written_key = key_file.read_bytes()
+        if len(written_key) != 32:
+            raise ValueError(
+                f'Model signing key at {key_file} is corrupted '
+                f'({len(written_key)} bytes, expected 32). '
+                'Delete the file and retry to generate a new key.'
+            )
+        logger.info('Generated new model signing key')
+        return written_key
+
+    def _compute_file_hmac(self, file_path: Path) -> str:
+        """Compute HMAC-SHA256 of a file for integrity verification.
+
+        Args:
+            file_path: Path to the file
+
+        Returns:
+            Hex-encoded HMAC-SHA256 string
+        """
+        with open(file_path, 'rb') as f:
+            data = f.read()
+        return self._compute_bytes_hmac(data)
+
+    def _compute_bytes_hmac(self, data: bytes) -> str:
+        """Compute HMAC-SHA256 of a byte buffer for integrity verification.
+
+        Args:
+            data: The bytes to compute the HMAC over
+
+        Returns:
+            Hex-encoded HMAC-SHA256 string
+        """
+        key = self._get_signing_key()
+        h = hmac_mod.new(key, data, digestmod=hashlib.sha256)
+        return h.hexdigest()
+
+    def _verify_file_hmac(self, file_path: Path, expected_hmac: str) -> bool:
+        """Verify HMAC-SHA256 of a file against an expected value.
+
+        Uses constant-time comparison to prevent timing attacks.
+
+        Args:
+            file_path: Path to the file to verify
+            expected_hmac: The expected HMAC hex string
+
+        Returns:
+            True if the HMAC matches
+        """
+        actual_hmac = self._compute_file_hmac(file_path)
+        return hmac_mod.compare_digest(actual_hmac, expected_hmac)
+
+    def _verify_bytes_hmac(self, data: bytes, expected_hmac: str) -> bool:
+        """Verify HMAC-SHA256 of a byte buffer against an expected value.
+
+        Uses constant-time comparison to prevent timing attacks.
+
+        Args:
+            data: The bytes to verify
+            expected_hmac: The expected HMAC hex string
+
+        Returns:
+            True if the HMAC matches
+        """
+        actual_hmac = self._compute_bytes_hmac(data)
+        return hmac_mod.compare_digest(actual_hmac, expected_hmac)
+
+    # ---- End security helpers ----------------------------------------------
+
     def _load_index(self) -> Dict[str, Any]:
         """Load the model index from disk."""
         try:
@@ -120,6 +300,12 @@ class ModelPersistenceManager:
     ) -> str:
         """Save a model to disk with metadata.
 
+        The save is performed atomically: the model is first written to a
+        temporary file, the HMAC is computed, the metadata (including HMAC)
+        is written, and only then the temp file is atomically renamed to
+        the final path.  This ensures no model file ever exists on disk
+        without a corresponding valid HMAC in the metadata sidecar.
+
         Args:
             model: The trained model object (e.g., IsolationForest)
             model_id: Unique identifier for the model
@@ -128,21 +314,49 @@ class ModelPersistenceManager:
         Returns:
             The model file path
         """
+        import tempfile
+
+        self._validate_model_id(model_id)
+
         model_file = self.storage_dir / f"{model_id}.joblib"
         meta_file = self.storage_dir / f"{model_id}.meta.json"
 
-        # Save model using joblib
-        joblib.dump(model, model_file)
+        # Step 1: Write model to a temporary file in the same directory.
+        # Using the same directory ensures os.rename() is atomic (same
+        # filesystem).
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.storage_dir), prefix=f'.{model_id}_tmp_', suffix='.joblib'
+        )
+        os.close(fd)
+        tmp_model_path = Path(tmp_path)
 
-        # Add timestamps to metadata
-        metadata["model_id"] = model_id
-        metadata["created_at"] = metadata.get("created_at", datetime.now().isoformat())
-        metadata["last_used_at"] = datetime.now().isoformat()
-        metadata["file_path"] = str(model_file)
+        try:
+            # Save model to temp file using joblib
+            joblib.dump(model, tmp_model_path)
 
-        # Save metadata
-        with open(meta_file, 'w') as f:
-            json.dump(metadata, f, indent=2)
+            # Step 2: Compute integrity HMAC over the temp file
+            model_hmac = self._compute_file_hmac(tmp_model_path)
+
+            # Step 3: Add timestamps and integrity signature to metadata
+            metadata["model_id"] = model_id
+            metadata["created_at"] = metadata.get("created_at", datetime.now().isoformat())
+            metadata["last_used_at"] = datetime.now().isoformat()
+            metadata["file_path"] = str(model_file)
+            metadata["model_hmac"] = model_hmac
+
+            # Write metadata (with HMAC) BEFORE renaming the model file.
+            with open(meta_file, 'w') as f:
+                json.dump(metadata, f, indent=2)
+
+            # Step 4: Atomically rename temp model file to final path.
+            # After this point, the model file and its HMAC are consistent.
+            os.replace(str(tmp_model_path), str(model_file))
+
+        except Exception:
+            # Clean up temp file on any failure
+            if tmp_model_path.exists():
+                tmp_model_path.unlink()
+            raise
 
         # Update index
         index = self._load_index()
@@ -174,6 +388,11 @@ class ModelPersistenceManager:
     def load_model(self, model_id: str) -> Tuple[Any, Dict[str, Any]]:
         """Load a model and its metadata from disk.
 
+        Performs security checks before deserialization:
+        - Validates model_id against path traversal attacks
+        - Verifies file integrity via HMAC-SHA256 signature
+        - Ensures the model file is within the expected storage directory
+
         Args:
             model_id: The model identifier to load
 
@@ -181,22 +400,71 @@ class ModelPersistenceManager:
             Tuple of (model, metadata)
 
         Raises:
-            FileNotFoundError: If model doesn't exist
+            FileNotFoundError: If the model file does not exist
+            ValueError: If model_id is invalid or integrity check fails
         """
+        self._validate_model_id(model_id)
+
         model_file = self.storage_dir / f"{model_id}.joblib"
         meta_file = self.storage_dir / f"{model_id}.meta.json"
 
         if not model_file.exists():
             raise FileNotFoundError(f"Model {model_id} not found at {model_file}")
 
-        # Load model
-        model = joblib.load(model_file)
+        # Read the model file bytes into memory ONCE.  Both HMAC
+        # verification and joblib deserialization operate on this same
+        # buffer, eliminating the TOCTOU window between disk-based
+        # _verify_file_hmac() and joblib.load() where an attacker could
+        # swap the file between the two calls.
+        model_bytes = model_file.read_bytes()
 
-        # Load metadata
+        # Load metadata first -- JSON deserialization is safe and gives us
+        # the HMAC we need to verify before touching joblib/pickle.
         metadata = {}
         if meta_file.exists():
             with open(meta_file, 'r') as f:
                 metadata = json.load(f)
+
+        # Determine strict vs. permissive mode for unsigned models.
+        # Strict mode (default) refuses to load models without an HMAC
+        # signature.  Legacy/permissive mode requires explicit opt-in via
+        # LUMINO_STRICT_MODEL_LOADING=false so existing deployments with
+        # unsigned models can migrate gracefully.
+        strict_mode = os.environ.get(
+            'LUMINO_STRICT_MODEL_LOADING', 'true'
+        ).lower() not in ('false', '0', 'no')
+
+        # Verify model file integrity before deserialization.
+        # joblib.load() uses pickle internally which can execute arbitrary
+        # code, so the file MUST be verified before it is deserialized.
+        stored_hmac = metadata.get('model_hmac')
+        if stored_hmac:
+            if not self._verify_bytes_hmac(model_bytes, stored_hmac):
+                raise ValueError(
+                    f'Model {model_id} failed integrity verification. '
+                    'The model file may have been tampered with. '
+                    'Re-train and save the model to generate a valid signature.'
+                )
+            logger.debug(f"Model {model_id} passed integrity verification")
+        else:
+            if strict_mode:
+                raise ValueError(
+                    f'Model {model_id} has no HMAC signature and strict '
+                    'model loading is enabled (default). Models without '
+                    'integrity signatures cannot be loaded. Re-save the '
+                    'model to generate an HMAC, or set '
+                    'LUMINO_STRICT_MODEL_LOADING=false to allow loading '
+                    'unsigned legacy models.'
+                )
+            logger.warning(
+                f'Model {model_id} has no HMAC signature. '
+                'Loading in permissive mode (LUMINO_STRICT_MODEL_LOADING=false). '
+                'This model was saved before integrity verification was added. '
+                'Re-save the model to generate an HMAC signature.'
+            )
+
+        # Deserialize from the in-memory buffer -- never re-read from disk.
+        model = joblib.load(io.BytesIO(model_bytes))
 
         # Update last used time
         metadata["last_used_at"] = datetime.now().isoformat()
@@ -208,11 +476,16 @@ class ModelPersistenceManager:
 
     def model_exists(self, model_id: str) -> bool:
         """Check if a model exists on disk."""
+        try:
+            self._validate_model_id(model_id)
+        except ValueError:
+            return False
         model_file = self.storage_dir / f"{model_id}.joblib"
         return model_file.exists()
 
     def get_model_metadata(self, model_id: str) -> Optional[Dict[str, Any]]:
         """Get metadata without loading the full model."""
+        self._validate_model_id(model_id)
         meta_file = self.storage_dir / f"{model_id}.meta.json"
 
         if not meta_file.exists():
@@ -247,6 +520,7 @@ class ModelPersistenceManager:
         Returns:
             True if deleted, False if not found
         """
+        self._validate_model_id(model_id)
         model_file = self.storage_dir / f"{model_id}.joblib"
         meta_file = self.storage_dir / f"{model_id}.meta.json"
 

--- a/tests/test_secure_model_deserialization.py
+++ b/tests/test_secure_model_deserialization.py
@@ -1,0 +1,404 @@
+"""Tests for secure model deserialization in ModelPersistenceManager.
+
+Verifies that:
+1. Model IDs are validated to prevent path-traversal attacks.
+2. Only alphanumeric/dot/hyphen/underscore characters are accepted.
+3. joblib.load paths are restricted to the expected storage directory.
+4. Model files are integrity-checked via HMAC-SHA256 before deserialization.
+5. Tampered model files are rejected.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add src/ to the path so we can import the module under test.
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR))
+
+# Load ml_persistence.py *directly* via importlib so that the helpers package
+# __init__.py (which eagerly re-exports every submodule and pulls in heavy
+# dependencies like pyyaml, kubernetes, etc.) is never executed.  The module
+# under test only needs stdlib + numpy + joblib — none of the heavy deps.
+_ML_PERSISTENCE_PATH = SRC_DIR / "helpers" / "ml_persistence.py"
+try:
+    _spec = importlib.util.spec_from_file_location(
+        "helpers.ml_persistence", _ML_PERSISTENCE_PATH
+    )
+    _mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+    ModelPersistenceManager = _mod.ModelPersistenceManager
+except (ImportError, ModuleNotFoundError, FileNotFoundError) as _imp_err:
+    pytest.skip(
+        f"Cannot import ModelPersistenceManager: {_imp_err}",
+        allow_module_level=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def manager(tmp_path: Path) -> ModelPersistenceManager:
+    """Return a ModelPersistenceManager rooted in a temporary directory."""
+    return ModelPersistenceManager(storage_dir=str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Model-ID validation
+# ---------------------------------------------------------------------------
+
+
+class TestModelIdValidation:
+    """_validate_model_id must reject unsafe identifiers."""
+
+    @pytest.mark.parametrize(
+        "bad_id,reason",
+        [
+            ("../../etc/passwd", "path traversal with ../"),
+            ("../evil", "single-level path traversal"),
+            ("foo/../../bar", "embedded path traversal"),
+            ("..%2F..%2Fetc%2Fpasswd", "URL-encoded path traversal"),
+            ("", "empty string"),
+            ("a" * 256, "exceeds 255-character limit"),
+            ("/absolute/path", "starts with slash"),
+            ("model id with spaces", "contains spaces"),
+            ("model;rm -rf", "contains semicolon"),
+            ("model\x00null", "contains null byte"),
+        ],
+    )
+    def test_rejects_unsafe_model_id(
+        self, manager: ModelPersistenceManager, bad_id: str, reason: str
+    ) -> None:
+        """model_id values with path-traversal or invalid characters are
+        rejected with ValueError.
+        """
+        with pytest.raises(ValueError):
+            manager._validate_model_id(bad_id)
+
+    @pytest.mark.parametrize(
+        "good_id",
+        [
+            "predictive_log_v1_20240101_120000",
+            "model-v2.3",
+            "a",
+            "A1_b2-c3.d4",
+        ],
+    )
+    def test_accepts_valid_model_id(
+        self, manager: ModelPersistenceManager, good_id: str
+    ) -> None:
+        """Legitimate model IDs pass validation without error."""
+        manager._validate_model_id(good_id)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Path restriction (joblib.load never escapes storage_dir)
+# ---------------------------------------------------------------------------
+
+
+class TestPathRestriction:
+    """All public methods that accept a model_id must refuse identifiers
+    whose resolved path falls outside the storage directory.
+    """
+
+    def test_load_model_rejects_traversal(
+        self, manager: ModelPersistenceManager
+    ) -> None:
+        with pytest.raises(ValueError):
+            manager.load_model("../../etc/passwd")
+
+    def test_save_model_rejects_traversal(
+        self, manager: ModelPersistenceManager
+    ) -> None:
+        with pytest.raises(ValueError):
+            manager.save_model(object(), "../../evil", {})
+
+    def test_delete_model_rejects_traversal(
+        self, manager: ModelPersistenceManager
+    ) -> None:
+        with pytest.raises(ValueError):
+            manager.delete_model("../../evil")
+
+    def test_model_exists_returns_false_for_traversal(
+        self, manager: ModelPersistenceManager
+    ) -> None:
+        """model_exists catches ValueError internally and returns False."""
+        assert manager.model_exists("../../evil") is False
+
+    def test_get_model_metadata_rejects_traversal(
+        self, manager: ModelPersistenceManager
+    ) -> None:
+        with pytest.raises(ValueError):
+            manager.get_model_metadata("../../evil")
+
+
+# ---------------------------------------------------------------------------
+# HMAC integrity verification
+# ---------------------------------------------------------------------------
+
+
+class TestIntegrityVerification:
+    """Model files must be integrity-checked before joblib.load."""
+
+    def _save_dummy_model(
+        self, manager: ModelPersistenceManager, model_id: str = "test_model"
+    ) -> Path:
+        """Save a trivial model via the manager and return the .joblib path."""
+        try:
+            import joblib  # noqa: F401
+        except ImportError:
+            pytest.skip("joblib not installed")
+
+        manager.save_model({"weights": [1, 2, 3]}, model_id, {"version": 1})
+        return manager.storage_dir / f"{model_id}.joblib"
+
+    def test_roundtrip_save_load_succeeds(
+        self, manager: ModelPersistenceManager
+    ) -> None:
+        """A model saved and loaded without modification passes integrity."""
+        self._save_dummy_model(manager)
+        model, metadata = manager.load_model("test_model")
+        assert model == {"weights": [1, 2, 3]}
+        assert "model_hmac" in metadata
+
+    def test_tampered_model_file_rejected(
+        self, manager: ModelPersistenceManager
+    ) -> None:
+        """Modifying the .joblib file after save causes integrity failure."""
+        model_file = self._save_dummy_model(manager)
+
+        # Tamper with the file by appending bytes
+        with open(model_file, "ab") as f:
+            f.write(b"TAMPERED")
+
+        with pytest.raises(ValueError, match="integrity"):
+            manager.load_model("test_model")
+
+    def test_replaced_model_file_rejected(
+        self, manager: ModelPersistenceManager
+    ) -> None:
+        """Completely replacing the .joblib file is detected."""
+        self._save_dummy_model(manager)
+        model_file = manager.storage_dir / "test_model.joblib"
+
+        # Replace with a different file
+        try:
+            import joblib
+        except ImportError:
+            pytest.skip("joblib not installed")
+
+        joblib.dump({"malicious": True}, model_file)
+
+        with pytest.raises(ValueError, match="integrity"):
+            manager.load_model("test_model")
+
+    def test_hmac_stored_in_metadata_on_save(
+        self, manager: ModelPersistenceManager
+    ) -> None:
+        """save_model must record model_hmac in the metadata sidecar."""
+        self._save_dummy_model(manager)
+        meta_file = manager.storage_dir / "test_model.meta.json"
+        assert meta_file.exists()
+
+        with open(meta_file) as f:
+            metadata = json.load(f)
+
+        assert "model_hmac" in metadata
+        assert isinstance(metadata["model_hmac"], str)
+        assert len(metadata["model_hmac"]) == 64  # SHA-256 hex digest
+
+    def test_strict_mode_rejects_missing_meta_json(
+        self, manager: ModelPersistenceManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In strict mode (default), a model with no .meta.json at all is
+        rejected because there is no HMAC to verify.
+        """
+        monkeypatch.setenv("LUMINO_STRICT_MODEL_LOADING", "true")
+        try:
+            import joblib
+        except ImportError:
+            pytest.skip("joblib not installed")
+
+        model_id = "no_meta_model"
+        model_file = manager.storage_dir / f"{model_id}.joblib"
+
+        # Write a model file with no accompanying metadata
+        joblib.dump({"orphan": True}, model_file)
+
+        # Update the index so the manager knows about it
+        index = manager._load_index()
+        index["models"].append(
+            {"model_id": model_id, "file_path": str(model_file), "is_active": False}
+        )
+        manager._save_index(index)
+
+        with pytest.raises(ValueError, match="no HMAC signature"):
+            manager.load_model(model_id)
+
+    def test_strict_mode_rejects_meta_without_hmac_key(
+        self, manager: ModelPersistenceManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In strict mode, a model with meta.json but no model_hmac key is
+        rejected.
+        """
+        monkeypatch.setenv("LUMINO_STRICT_MODEL_LOADING", "true")
+        try:
+            import joblib
+        except ImportError:
+            pytest.skip("joblib not installed")
+
+        model_id = "legacy_no_hmac"
+        model_file = manager.storage_dir / f"{model_id}.joblib"
+        meta_file = manager.storage_dir / f"{model_id}.meta.json"
+
+        joblib.dump({"old": True}, model_file)
+        with open(meta_file, "w") as f:
+            json.dump({"model_id": model_id, "version": 0}, f)
+
+        index = manager._load_index()
+        index["models"].append(
+            {"model_id": model_id, "file_path": str(model_file), "is_active": False}
+        )
+        manager._save_index(index)
+
+        with pytest.raises(ValueError, match="no HMAC signature"):
+            manager.load_model(model_id)
+
+    def test_tampered_hmac_value_rejected(
+        self, manager: ModelPersistenceManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A model with a tampered (wrong) HMAC value is rejected."""
+        monkeypatch.setenv("LUMINO_STRICT_MODEL_LOADING", "true")
+        self._save_dummy_model(manager)
+        meta_file = manager.storage_dir / "test_model.meta.json"
+
+        # Tamper with the stored HMAC
+        with open(meta_file) as f:
+            metadata = json.load(f)
+        metadata["model_hmac"] = "a" * 64  # wrong HMAC
+        with open(meta_file, "w") as f:
+            json.dump(metadata, f, indent=2)
+
+        with pytest.raises(ValueError, match="integrity"):
+            manager.load_model("test_model")
+
+    def test_stripped_hmac_from_existing_metadata_rejected(
+        self, manager: ModelPersistenceManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stripping model_hmac from an existing metadata file must not
+        allow loading in strict mode -- this is a downgrade attack.
+        """
+        monkeypatch.setenv("LUMINO_STRICT_MODEL_LOADING", "true")
+        self._save_dummy_model(manager)
+        meta_file = manager.storage_dir / "test_model.meta.json"
+
+        # Remove the model_hmac key from metadata (downgrade attack)
+        with open(meta_file) as f:
+            metadata = json.load(f)
+        del metadata["model_hmac"]
+        with open(meta_file, "w") as f:
+            json.dump(metadata, f, indent=2)
+
+        with pytest.raises(ValueError, match="no HMAC signature"):
+            manager.load_model("test_model")
+
+    def test_permissive_mode_allows_legacy_model(
+        self, manager: ModelPersistenceManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When LUMINO_STRICT_MODEL_LOADING=false, legacy models without
+        HMAC load with a warning (not an error) for migration purposes.
+        """
+        monkeypatch.setenv("LUMINO_STRICT_MODEL_LOADING", "false")
+        try:
+            import joblib
+        except ImportError:
+            pytest.skip("joblib not installed")
+
+        model_id = "legacy_model"
+        model_file = manager.storage_dir / f"{model_id}.joblib"
+        meta_file = manager.storage_dir / f"{model_id}.meta.json"
+
+        # Simulate a legacy save: write model and metadata without HMAC
+        joblib.dump({"old": True}, model_file)
+        with open(meta_file, "w") as f:
+            json.dump({"model_id": model_id, "version": 0}, f)
+
+        index = manager._load_index()
+        index["models"].append(
+            {"model_id": model_id, "file_path": str(model_file), "is_active": False}
+        )
+        manager._save_index(index)
+
+        # Should load successfully in permissive mode
+        model, metadata = manager.load_model(model_id)
+        assert model == {"old": True}
+
+
+# ---------------------------------------------------------------------------
+# Signing key management
+# ---------------------------------------------------------------------------
+
+
+class TestSigningKey:
+    """The per-installation signing key must be created deterministically
+    and reused across calls.
+    """
+
+    def test_signing_key_created_on_first_use(
+        self,
+        manager: ModelPersistenceManager,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        # Redirect Path.home() to tmp_path so we don't touch the real
+        # ~/.lumino directory during tests.
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+        key_file = fake_home / ".lumino" / ModelPersistenceManager._SIGNING_KEY_FILE
+        assert not key_file.exists()
+        key = manager._get_signing_key()
+        assert key_file.exists()
+        assert len(key) == 32  # 256-bit key
+
+    def test_signing_key_reused(
+        self,
+        manager: ModelPersistenceManager,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Subsequent calls return the same key."""
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+        key1 = manager._get_signing_key()
+        key2 = manager._get_signing_key()
+        assert key1 == key2
+
+    def test_corrupted_key_file_rejected(
+        self,
+        manager: ModelPersistenceManager,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A truncated or empty key file raises ValueError."""
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+        key_dir = fake_home / ".lumino"
+        key_dir.mkdir(parents=True, exist_ok=True)
+        key_file = key_dir / ModelPersistenceManager._SIGNING_KEY_FILE
+        # Write a truncated key (only 10 bytes instead of 32)
+        key_file.write_bytes(b"x" * 10)
+
+        with pytest.raises(ValueError, match="corrupted"):
+            manager._get_signing_key()


### PR DESCRIPTION
## Summary

- Add HMAC-SHA256 signing and verification to ML model persistence so that joblib/pickle files are integrity-checked before deserialization, preventing arbitrary code execution from tampered model files
- Validate model IDs against path traversal and injection attacks
- Atomic model file writes to prevent partial/corrupt files on disk

Replaces #154 (which bundled unrelated formatting changes causing merge conflicts).

## Test plan

- [ ] Verify model ID validation rejects path traversal attempts
- [ ] Verify HMAC is computed on save and verified on load
- [ ] Verify tampered model files are rejected
- [ ] Run `pytest tests/test_secure_model_deserialization.py`