### PR TITLE
fix: close SQLite connections via context manager in TrainingDataStore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ Issues = "https://github.com/spre-sre/lumino-mcp-server/issues"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
 

--- a/src/helpers/ml_persistence.py
+++ b/src/helpers/ml_persistence.py
@@ -18,6 +18,7 @@ import re
 import sqlite3
 from pathlib import Path
 from datetime import datetime, timedelta
+from contextlib import contextmanager
 from typing import Dict, List, Any, Optional, Tuple
 import numpy as np
 
@@ -626,90 +627,89 @@ class TrainingDataStore:
 
     def _init_database(self) -> None:
         """Initialize SQLite database schema."""
-        conn = sqlite3.connect(str(self.db_path))
-        cursor = conn.cursor()
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
 
-        # Log samples table - includes cluster_id for multi-cluster support
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS log_samples (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                sample_hash TEXT UNIQUE,
-                cluster_id TEXT,
-                timestamp TEXT,
-                namespace TEXT,
-                pod_name TEXT,
-                features BLOB,
-                raw_message TEXT,
-                log_level TEXT,
-                error_indicators INTEGER,
-                message_entropy REAL,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP
-            )
-        """)
+            # Log samples table - includes cluster_id for multi-cluster support
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS log_samples (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    sample_hash TEXT UNIQUE,
+                    cluster_id TEXT,
+                    timestamp TEXT,
+                    namespace TEXT,
+                    pod_name TEXT,
+                    features BLOB,
+                    raw_message TEXT,
+                    log_level TEXT,
+                    error_indicators INTEGER,
+                    message_entropy REAL,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
 
-        # Failure labels table - includes cluster_id for multi-cluster support
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS failure_labels (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                failure_id TEXT UNIQUE,
-                cluster_id TEXT,
-                failure_type TEXT,
-                severity TEXT,
-                namespace TEXT,
-                resource_name TEXT,
-                resource_type TEXT,
-                failure_time TEXT,
-                detection_source TEXT,
-                error_category TEXT,
-                metadata TEXT,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP
-            )
-        """)
+            # Failure labels table - includes cluster_id for multi-cluster support
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS failure_labels (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    failure_id TEXT UNIQUE,
+                    cluster_id TEXT,
+                    failure_type TEXT,
+                    severity TEXT,
+                    namespace TEXT,
+                    resource_name TEXT,
+                    resource_type TEXT,
+                    failure_time TEXT,
+                    detection_source TEXT,
+                    error_category TEXT,
+                    metadata TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
 
-        # Log-Failure correlation table
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS log_failure_correlations (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                log_sample_id INTEGER REFERENCES log_samples(id),
-                failure_label_id INTEGER REFERENCES failure_labels(id),
-                cluster_id TEXT,
-                correlation_score REAL,
-                time_delta_seconds INTEGER,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                UNIQUE(log_sample_id, failure_label_id)
-            )
-        """)
+            # Log-Failure correlation table
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS log_failure_correlations (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    log_sample_id INTEGER REFERENCES log_samples(id),
+                    failure_label_id INTEGER REFERENCES failure_labels(id),
+                    cluster_id TEXT,
+                    correlation_score REAL,
+                    time_delta_seconds INTEGER,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(log_sample_id, failure_label_id)
+                )
+            """)
 
-        # Training run history - includes cluster_id
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS training_runs (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                model_id TEXT,
-                cluster_id TEXT,
-                training_started TEXT,
-                training_completed TEXT,
-                samples_used INTEGER,
-                labels_used INTEGER,
-                performance_metrics TEXT,
-                trigger_reason TEXT,
-                status TEXT
-            )
-        """)
+            # Training run history - includes cluster_id
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS training_runs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    model_id TEXT,
+                    cluster_id TEXT,
+                    training_started TEXT,
+                    training_completed TEXT,
+                    samples_used INTEGER,
+                    labels_used INTEGER,
+                    performance_metrics TEXT,
+                    trigger_reason TEXT,
+                    status TEXT
+                )
+            """)
 
-        # Create indexes
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_log_samples_namespace ON log_samples(namespace)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_log_samples_timestamp ON log_samples(timestamp)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_log_samples_cluster ON log_samples(cluster_id)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_failure_labels_type ON failure_labels(failure_type)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_failure_labels_time ON failure_labels(failure_time)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_failure_labels_namespace ON failure_labels(namespace)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_failure_labels_cluster ON failure_labels(cluster_id)")
+            # Create indexes
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_log_samples_namespace ON log_samples(namespace)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_log_samples_timestamp ON log_samples(timestamp)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_log_samples_cluster ON log_samples(cluster_id)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_failure_labels_type ON failure_labels(failure_type)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_failure_labels_time ON failure_labels(failure_time)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_failure_labels_namespace ON failure_labels(namespace)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_failure_labels_cluster ON failure_labels(cluster_id)")
 
-        # Migration: Add cluster_id column to existing tables if not present
-        self._migrate_add_cluster_id(cursor)
+            # Migration: Add cluster_id column to existing tables if not present
+            self._migrate_add_cluster_id(cursor)
 
-        conn.commit()
-        conn.close()
+            conn.commit()
 
         logger.debug(f"Initialized training data store at {self.db_path}")
 
@@ -734,9 +734,18 @@ class TrainingDataStore:
             except sqlite3.Error as e:
                 logger.debug(f"Migration for {table}: {e}")
 
-    def _get_connection(self) -> sqlite3.Connection:
-        """Get a database connection."""
-        return sqlite3.connect(str(self.db_path))
+    @contextmanager
+    def _get_connection(self):
+        """Get a database connection as a context manager.
+
+        Yields:
+            sqlite3.Connection that is guaranteed to close on block exit.
+        """
+        conn = sqlite3.connect(str(self.db_path))
+        try:
+            yield conn
+        finally:
+            conn.close()
 
     def store_log_sample(self, sample: Dict[str, Any], cluster_id: Optional[str] = None) -> Optional[int]:
         """Store a preprocessed log sample.
@@ -766,35 +775,33 @@ class TrainingDataStore:
             elif isinstance(features, list):
                 features_blob = np.array(features).tobytes()
 
-        conn = self._get_connection()
-        cursor = conn.cursor()
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
 
-        try:
-            cursor.execute("""
-                INSERT OR IGNORE INTO log_samples
-                (sample_hash, cluster_id, timestamp, namespace, pod_name, features,
-                 raw_message, log_level, error_indicators, message_entropy)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (
-                sample_hash,
-                cluster_id,
-                sample.get("timestamp"),
-                sample.get("namespace"),
-                sample.get("pod_name"),
-                features_blob,
-                sample.get("raw_message", "")[:1000],  # Limit message size
-                sample.get("log_level"),
-                sample.get("error_indicators", 0),
-                sample.get("message_entropy", 0.0)
-            ))
+            try:
+                cursor.execute("""
+                    INSERT OR IGNORE INTO log_samples
+                    (sample_hash, cluster_id, timestamp, namespace, pod_name, features,
+                     raw_message, log_level, error_indicators, message_entropy)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, (
+                    sample_hash,
+                    cluster_id,
+                    sample.get("timestamp"),
+                    sample.get("namespace"),
+                    sample.get("pod_name"),
+                    features_blob,
+                    sample.get("raw_message", "")[:1000],  # Limit message size
+                    sample.get("log_level"),
+                    sample.get("error_indicators", 0),
+                    sample.get("message_entropy", 0.0)
+                ))
 
-            conn.commit()
-            return cursor.lastrowid if cursor.rowcount > 0 else None
-        except sqlite3.Error as e:
-            logger.warning(f"Failed to store log sample: {e}")
-            return None
-        finally:
-            conn.close()
+                conn.commit()
+                return cursor.lastrowid if cursor.rowcount > 0 else None
+            except sqlite3.Error as e:
+                logger.warning(f"Failed to store log sample: {e}")
+                return None
 
     def store_failure_label(self, label: Dict[str, Any], cluster_id: Optional[str] = None) -> Optional[int]:
         """Store a failure label.
@@ -823,36 +830,34 @@ class TrainingDataStore:
         if "metadata" in label and label["metadata"]:
             metadata_str = json.dumps(label["metadata"])
 
-        conn = self._get_connection()
-        cursor = conn.cursor()
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
 
-        try:
-            cursor.execute("""
-                INSERT OR IGNORE INTO failure_labels
-                (failure_id, cluster_id, failure_type, severity, namespace, resource_name,
-                 resource_type, failure_time, detection_source, error_category, metadata)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (
-                failure_id,
-                cluster_id,
-                label.get("failure_type"),
-                label.get("severity"),
-                label.get("namespace"),
-                label.get("resource_name"),
-                label.get("resource_type"),
-                label.get("failure_time"),
-                label.get("detection_source"),
-                label.get("error_category"),
-                metadata_str
-            ))
+            try:
+                cursor.execute("""
+                    INSERT OR IGNORE INTO failure_labels
+                    (failure_id, cluster_id, failure_type, severity, namespace, resource_name,
+                     resource_type, failure_time, detection_source, error_category, metadata)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, (
+                    failure_id,
+                    cluster_id,
+                    label.get("failure_type"),
+                    label.get("severity"),
+                    label.get("namespace"),
+                    label.get("resource_name"),
+                    label.get("resource_type"),
+                    label.get("failure_time"),
+                    label.get("detection_source"),
+                    label.get("error_category"),
+                    metadata_str
+                ))
 
-            conn.commit()
-            return cursor.lastrowid if cursor.rowcount > 0 else None
-        except sqlite3.Error as e:
-            logger.warning(f"Failed to store failure label: {e}")
-            return None
-        finally:
-            conn.close()
+                conn.commit()
+                return cursor.lastrowid if cursor.rowcount > 0 else None
+            except sqlite3.Error as e:
+                logger.warning(f"Failed to store failure label: {e}")
+                return None
 
     def store_correlation(
         self,
@@ -862,23 +867,21 @@ class TrainingDataStore:
         time_delta_seconds: int
     ) -> Optional[int]:
         """Store a log-failure correlation."""
-        conn = self._get_connection()
-        cursor = conn.cursor()
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
 
-        try:
-            cursor.execute("""
-                INSERT OR IGNORE INTO log_failure_correlations
-                (log_sample_id, failure_label_id, correlation_score, time_delta_seconds)
-                VALUES (?, ?, ?, ?)
-            """, (log_sample_id, failure_label_id, correlation_score, time_delta_seconds))
+            try:
+                cursor.execute("""
+                    INSERT OR IGNORE INTO log_failure_correlations
+                    (log_sample_id, failure_label_id, correlation_score, time_delta_seconds)
+                    VALUES (?, ?, ?, ?)
+                """, (log_sample_id, failure_label_id, correlation_score, time_delta_seconds))
 
-            conn.commit()
-            return cursor.lastrowid if cursor.rowcount > 0 else None
-        except sqlite3.Error as e:
-            logger.warning(f"Failed to store correlation: {e}")
-            return None
-        finally:
-            conn.close()
+                conn.commit()
+                return cursor.lastrowid if cursor.rowcount > 0 else None
+            except sqlite3.Error as e:
+                logger.warning(f"Failed to store correlation: {e}")
+                return None
 
     def get_failure_labels_in_window(
         self,
@@ -902,67 +905,66 @@ class TrainingDataStore:
         Returns:
             List of failure label dicts
         """
-        conn = self._get_connection()
-        cursor = conn.cursor()
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
 
-        query = """
-            SELECT id, failure_id, cluster_id, failure_type, severity, namespace, resource_name,
-                   resource_type, failure_time, detection_source, error_category, metadata
-            FROM failure_labels
-            WHERE failure_time >= ? AND failure_time <= ?
-        """
-        params = [start_time.isoformat(), end_time.isoformat()]
+            query = """
+                SELECT id, failure_id, cluster_id, failure_type, severity, namespace, resource_name,
+                       resource_type, failure_time, detection_source, error_category, metadata
+                FROM failure_labels
+                WHERE failure_time >= ? AND failure_time <= ?
+            """
+            params = [start_time.isoformat(), end_time.isoformat()]
 
-        # Filter by cluster
-        if cluster_id:
-            query += " AND cluster_id = ?"
-            params.append(cluster_id)
-        elif current_cluster_only:
-            current = get_current_cluster_id()
-            # Include both current cluster and legacy data without cluster_id
-            query += " AND (cluster_id = ? OR cluster_id IS NULL)"
-            params.append(current)
+            # Filter by cluster
+            if cluster_id:
+                query += " AND cluster_id = ?"
+                params.append(cluster_id)
+            elif current_cluster_only:
+                current = get_current_cluster_id()
+                # Include both current cluster and legacy data without cluster_id
+                query += " AND (cluster_id = ? OR cluster_id IS NULL)"
+                params.append(current)
 
-        if failure_types:
-            placeholders = ",".join("?" * len(failure_types))
-            query += f" AND failure_type IN ({placeholders})"
-            params.extend(failure_types)
+            if failure_types:
+                placeholders = ",".join("?" * len(failure_types))
+                query += f" AND failure_type IN ({placeholders})"
+                params.extend(failure_types)
 
-        if namespace:
-            query += " AND namespace = ?"
-            params.append(namespace)
+            if namespace:
+                query += " AND namespace = ?"
+                params.append(namespace)
 
-        query += " ORDER BY failure_time DESC"
+            query += " ORDER BY failure_time DESC"
 
-        cursor.execute(query, params)
-        rows = cursor.fetchall()
-        conn.close()
+            cursor.execute(query, params)
+            rows = cursor.fetchall()
 
-        labels = []
-        for row in rows:
-            metadata = None
-            if row[11]:
-                try:
-                    metadata = json.loads(row[11])
-                except json.JSONDecodeError:
-                    metadata = {}
+            labels = []
+            for row in rows:
+                metadata = None
+                if row[11]:
+                    try:
+                        metadata = json.loads(row[11])
+                    except json.JSONDecodeError:
+                        metadata = {}
 
-            labels.append({
-                "id": row[0],
-                "failure_id": row[1],
-                "cluster_id": row[2],
-                "failure_type": row[3],
-                "severity": row[4],
-                "namespace": row[5],
-                "resource_name": row[6],
-                "resource_type": row[7],
-                "failure_time": row[8],
-                "detection_source": row[9],
-                "error_category": row[10],
-                "metadata": metadata
-            })
+                labels.append({
+                    "id": row[0],
+                    "failure_id": row[1],
+                    "cluster_id": row[2],
+                    "failure_type": row[3],
+                    "severity": row[4],
+                    "namespace": row[5],
+                    "resource_name": row[6],
+                    "resource_type": row[7],
+                    "failure_time": row[8],
+                    "detection_source": row[9],
+                    "error_category": row[10],
+                    "metadata": metadata
+                })
 
-        return labels
+            return labels
 
     def get_training_data(
         self,
@@ -980,60 +982,58 @@ class TrainingDataStore:
         Returns:
             Tuple of (samples list, total count)
         """
-        conn = self._get_connection()
-        cursor = conn.cursor()
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
 
-        query = "SELECT * FROM log_samples WHERE 1=1"
-        params = []
+            query = "SELECT * FROM log_samples WHERE 1=1"
+            params = []
 
-        if since:
-            query += " AND created_at >= ?"
-            params.append(since.isoformat())
+            if since:
+                query += " AND created_at >= ?"
+                params.append(since.isoformat())
 
-        if namespace:
-            query += " AND namespace = ?"
-            params.append(namespace)
+            if namespace:
+                query += " AND namespace = ?"
+                params.append(namespace)
 
-        query += " ORDER BY created_at DESC"
+            query += " ORDER BY created_at DESC"
 
-        if limit:
-            query += f" LIMIT {limit}"
+            if limit:
+                query += f" LIMIT {limit}"
 
-        cursor.execute(query, params)
-        rows = cursor.fetchall()
+            cursor.execute(query, params)
+            rows = cursor.fetchall()
 
-        # Get total count
-        count_query = "SELECT COUNT(*) FROM log_samples WHERE 1=1"
-        count_params = []
-        if since:
-            count_query += " AND created_at >= ?"
-            count_params.append(since.isoformat())
-        if namespace:
-            count_query += " AND namespace = ?"
-            count_params.append(namespace)
+            # Get total count
+            count_query = "SELECT COUNT(*) FROM log_samples WHERE 1=1"
+            count_params = []
+            if since:
+                count_query += " AND created_at >= ?"
+                count_params.append(since.isoformat())
+            if namespace:
+                count_query += " AND namespace = ?"
+                count_params.append(namespace)
 
-        cursor.execute(count_query, count_params)
-        total_count = cursor.fetchone()[0]
+            cursor.execute(count_query, count_params)
+            total_count = cursor.fetchone()[0]
 
-        conn.close()
+            samples = []
+            for row in rows:
+                samples.append({
+                    "id": row[0],
+                    "sample_hash": row[1],
+                    "timestamp": row[2],
+                    "namespace": row[3],
+                    "pod_name": row[4],
+                    "features": row[5],
+                    "raw_message": row[6],
+                    "log_level": row[7],
+                    "error_indicators": row[8],
+                    "message_entropy": row[9],
+                    "created_at": row[10]
+                })
 
-        samples = []
-        for row in rows:
-            samples.append({
-                "id": row[0],
-                "sample_hash": row[1],
-                "timestamp": row[2],
-                "namespace": row[3],
-                "pod_name": row[4],
-                "features": row[5],
-                "raw_message": row[6],
-                "log_level": row[7],
-                "error_indicators": row[8],
-                "message_entropy": row[9],
-                "created_at": row[10]
-            })
-
-        return samples, total_count
+            return samples, total_count
 
     def get_statistics(self, current_cluster_only: bool = False) -> Dict[str, Any]:
         """Get statistics about stored training data.
@@ -1044,62 +1044,61 @@ class TrainingDataStore:
         Returns:
             Dict with statistics
         """
-        conn = self._get_connection()
-        cursor = conn.cursor()
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
 
-        stats = {}
-        current_cluster = get_current_cluster_id()
-        stats["current_cluster"] = current_cluster
+            stats = {}
+            current_cluster = get_current_cluster_id()
+            stats["current_cluster"] = current_cluster
 
-        # Build cluster filter (parameterized to prevent SQL injection)
-        if current_cluster_only and current_cluster:
-            cluster_where = " WHERE (cluster_id = ? OR cluster_id IS NULL)"
-            cluster_and = " AND (cluster_id = ? OR cluster_id IS NULL)"
-            cluster_params = [current_cluster]
-        else:
-            cluster_where = ""
-            cluster_and = ""
-            cluster_params = []
+            # Build cluster filter (parameterized to prevent SQL injection)
+            if current_cluster_only and current_cluster:
+                cluster_where = " WHERE (cluster_id = ? OR cluster_id IS NULL)"
+                cluster_and = " AND (cluster_id = ? OR cluster_id IS NULL)"
+                cluster_params = [current_cluster]
+            else:
+                cluster_where = ""
+                cluster_and = ""
+                cluster_params = []
 
-        # Log samples stats
-        cursor.execute(f"SELECT COUNT(*) FROM log_samples{cluster_where}", cluster_params)
-        stats["total_log_samples"] = cursor.fetchone()[0]
+            # Log samples stats
+            cursor.execute(f"SELECT COUNT(*) FROM log_samples{cluster_where}", cluster_params)
+            stats["total_log_samples"] = cursor.fetchone()[0]
 
-        cursor.execute(f"SELECT COUNT(DISTINCT namespace) FROM log_samples{cluster_where}", cluster_params)
-        stats["unique_namespaces"] = cursor.fetchone()[0]
+            cursor.execute(f"SELECT COUNT(DISTINCT namespace) FROM log_samples{cluster_where}", cluster_params)
+            stats["unique_namespaces"] = cursor.fetchone()[0]
 
-        # Cluster distribution for log samples
-        cursor.execute("SELECT cluster_id, COUNT(*) FROM log_samples GROUP BY cluster_id")
-        stats["log_samples_by_cluster"] = {(k or "legacy"): v for k, v in cursor.fetchall()}
+            # Cluster distribution for log samples
+            cursor.execute("SELECT cluster_id, COUNT(*) FROM log_samples GROUP BY cluster_id")
+            stats["log_samples_by_cluster"] = {(k or "legacy"): v for k, v in cursor.fetchall()}
 
-        # Failure labels stats
-        cursor.execute(f"SELECT COUNT(*) FROM failure_labels{cluster_where}", cluster_params)
-        stats["total_failure_labels"] = cursor.fetchone()[0]
+            # Failure labels stats
+            cursor.execute(f"SELECT COUNT(*) FROM failure_labels{cluster_where}", cluster_params)
+            stats["total_failure_labels"] = cursor.fetchone()[0]
 
-        cursor.execute(f"SELECT failure_type, COUNT(*) FROM failure_labels{' WHERE 1=1' + cluster_and if cluster_and else ''} GROUP BY failure_type", cluster_params)
-        stats["failure_types"] = dict(cursor.fetchall())
+            cursor.execute(f"SELECT failure_type, COUNT(*) FROM failure_labels{' WHERE 1=1' + cluster_and if cluster_and else ''} GROUP BY failure_type", cluster_params)
+            stats["failure_types"] = dict(cursor.fetchall())
 
-        cursor.execute(f"SELECT severity, COUNT(*) FROM failure_labels{' WHERE 1=1' + cluster_and if cluster_and else ''} GROUP BY severity", cluster_params)
-        stats["severity_distribution"] = dict(cursor.fetchall())
+            cursor.execute(f"SELECT severity, COUNT(*) FROM failure_labels{' WHERE 1=1' + cluster_and if cluster_and else ''} GROUP BY severity", cluster_params)
+            stats["severity_distribution"] = dict(cursor.fetchall())
 
-        # Cluster distribution for failure labels
-        cursor.execute("SELECT cluster_id, COUNT(*) FROM failure_labels GROUP BY cluster_id")
-        stats["failure_labels_by_cluster"] = {(k or "legacy"): v for k, v in cursor.fetchall()}
+            # Cluster distribution for failure labels
+            cursor.execute("SELECT cluster_id, COUNT(*) FROM failure_labels GROUP BY cluster_id")
+            stats["failure_labels_by_cluster"] = {(k or "legacy"): v for k, v in cursor.fetchall()}
 
-        # Correlations
-        cursor.execute(f"SELECT COUNT(*) FROM log_failure_correlations")
-        stats["total_correlations"] = cursor.fetchone()[0]
+            # Correlations
+            cursor.execute(f"SELECT COUNT(*) FROM log_failure_correlations")
+            stats["total_correlations"] = cursor.fetchone()[0]
 
-        # Training runs
-        cursor.execute("SELECT COUNT(*) FROM training_runs")
-        stats["total_training_runs"] = cursor.fetchone()[0]
+            # Training runs
+            cursor.execute("SELECT COUNT(*) FROM training_runs")
+            stats["total_training_runs"] = cursor.fetchone()[0]
 
-        cursor.execute("SELECT MAX(training_completed) FROM training_runs WHERE status = 'completed'")
-        result = cursor.fetchone()
-        stats["last_training"] = result[0] if result else None
+            cursor.execute("SELECT MAX(training_completed) FROM training_runs WHERE status = 'completed'")
+            result = cursor.fetchone()
+            stats["last_training"] = result[0] if result else None
 
-        conn.close()
-        return stats
+            return stats
 
     def record_training_run(
         self,
@@ -1111,30 +1110,27 @@ class TrainingDataStore:
         status: str = "completed"
     ) -> int:
         """Record a training run in history."""
-        conn = self._get_connection()
-        cursor = conn.cursor()
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
 
-        cursor.execute("""
-            INSERT INTO training_runs
-            (model_id, training_started, training_completed, samples_used,
-             labels_used, performance_metrics, trigger_reason, status)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        """, (
-            model_id,
-            datetime.now().isoformat(),
-            datetime.now().isoformat(),
-            samples_used,
-            labels_used,
-            json.dumps(performance_metrics),
-            trigger_reason,
-            status
-        ))
+            cursor.execute("""
+                INSERT INTO training_runs
+                (model_id, training_started, training_completed, samples_used,
+                 labels_used, performance_metrics, trigger_reason, status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                model_id,
+                datetime.now().isoformat(),
+                datetime.now().isoformat(),
+                samples_used,
+                labels_used,
+                json.dumps(performance_metrics),
+                trigger_reason,
+                status
+            ))
 
-        conn.commit()
-        run_id = cursor.lastrowid
-        conn.close()
-
-        return run_id
+            conn.commit()
+            return cursor.lastrowid
 
     def cleanup_old_data(self, max_age_days: int = 90) -> int:
         """Remove old training data.
@@ -1147,30 +1143,29 @@ class TrainingDataStore:
         """
         cutoff = (datetime.now() - timedelta(days=max_age_days)).isoformat()
 
-        conn = self._get_connection()
-        cursor = conn.cursor()
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
 
-        deleted = 0
+            deleted = 0
 
-        # Delete old correlations first (foreign key constraint)
-        cursor.execute("""
-            DELETE FROM log_failure_correlations
-            WHERE log_sample_id IN (
-                SELECT id FROM log_samples WHERE created_at < ?
-            )
-        """, (cutoff,))
-        deleted += cursor.rowcount
+            # Delete old correlations first (foreign key constraint)
+            cursor.execute("""
+                DELETE FROM log_failure_correlations
+                WHERE log_sample_id IN (
+                    SELECT id FROM log_samples WHERE created_at < ?
+                )
+            """, (cutoff,))
+            deleted += cursor.rowcount
 
-        # Delete old log samples
-        cursor.execute("DELETE FROM log_samples WHERE created_at < ?", (cutoff,))
-        deleted += cursor.rowcount
+            # Delete old log samples
+            cursor.execute("DELETE FROM log_samples WHERE created_at < ?", (cutoff,))
+            deleted += cursor.rowcount
 
-        # Delete old failure labels
-        cursor.execute("DELETE FROM failure_labels WHERE created_at < ?", (cutoff,))
-        deleted += cursor.rowcount
+            # Delete old failure labels
+            cursor.execute("DELETE FROM failure_labels WHERE created_at < ?", (cutoff,))
+            deleted += cursor.rowcount
 
-        conn.commit()
-        conn.close()
+            conn.commit()
 
         if deleted > 0:
             logger.info(f"Cleaned up {deleted} old training data records")

--- a/tests/test_ml_persistence_connection.py
+++ b/tests/test_ml_persistence_connection.py
@@ -1,0 +1,226 @@
+"""Tests for SQLite connection lifecycle in TrainingDataStore.
+
+Verifies that:
+1. _get_connection() yields a working sqlite3.Connection via context manager.
+2. Connections are reliably closed on normal exit and on exception.
+3. Exceptions propagate through the context manager without being swallowed.
+4. Public methods (store_log_sample, store_failure_label, etc.) work end-to-end.
+5. Only _get_connection's finally block contains conn.close() (no leak sites).
+"""
+
+import importlib.util
+import sqlite3
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Direct-import of ml_persistence.py (avoids heavy helpers/__init__.py)
+# ---------------------------------------------------------------------------
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR))
+
+_ML_PERSISTENCE_PATH = SRC_DIR / "helpers" / "ml_persistence.py"
+try:
+    _spec = importlib.util.spec_from_file_location(
+        "helpers.ml_persistence", _ML_PERSISTENCE_PATH
+    )
+    _mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+    TrainingDataStore = _mod.TrainingDataStore
+except (ImportError, ModuleNotFoundError, FileNotFoundError) as _imp_err:
+    pytest.skip(
+        f"Cannot import TrainingDataStore: {_imp_err}",
+        allow_module_level=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def store(tmp_path: Path) -> TrainingDataStore:
+    """Create a TrainingDataStore backed by a temp directory.
+
+    Patches get_current_cluster_id so tests run without kubeconfig.
+    """
+    with patch.object(_mod, "get_current_cluster_id", return_value="test-cluster"):
+        return TrainingDataStore(storage_dir=str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# _get_connection context-manager behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_yields_live_sqlite_connection(store):
+    """_get_connection() yields a working sqlite3.Connection."""
+    with store._get_connection() as conn:
+        assert isinstance(conn, sqlite3.Connection)
+        result = conn.execute("SELECT 1").fetchone()
+        assert result == (1,)
+
+
+def test_closes_connection_on_normal_exit(store):
+    """Connection is closed after the with-block exits normally."""
+    with store._get_connection() as conn:
+        pass  # normal exit
+
+    # After closing, any operation should raise ProgrammingError
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")
+
+
+def test_closes_connection_on_exception(store):
+    """Connection is closed even when the with-block raises."""
+    with pytest.raises(RuntimeError):
+        with store._get_connection() as conn:
+            raise RuntimeError("deliberate")
+
+    # Connection must still be closed
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")
+
+
+def test_exception_propagates_through_context_manager(store):
+    """Exceptions inside the with-block are NOT swallowed."""
+    with pytest.raises(ValueError, match="propagated"):
+        with store._get_connection() as conn:
+            raise ValueError("propagated")
+
+
+def test_get_connection_returns_context_manager(store):
+    """The object returned by _get_connection() supports the context-manager protocol."""
+    cm = store._get_connection()
+    assert hasattr(cm, "__enter__"), "_get_connection result must have __enter__"
+    assert hasattr(cm, "__exit__"), "_get_connection result must have __exit__"
+
+
+# ---------------------------------------------------------------------------
+# Public method roundtrip tests
+# ---------------------------------------------------------------------------
+
+
+def test_store_log_sample_roundtrip(store):
+    """store_log_sample returns a non-None integer row ID."""
+    with patch.object(_mod, "get_current_cluster_id", return_value="test-cluster"):
+        sample = {
+            "timestamp": datetime.now().isoformat(),
+            "namespace": "test-ns",
+            "pod_name": "test-pod-abc",
+            "raw_message": "ERROR something went wrong",
+            "log_level": "ERROR",
+            "error_indicators": 1,
+            "message_entropy": 3.14,
+        }
+        row_id = store.store_log_sample(sample)
+        assert row_id is not None
+        assert isinstance(row_id, int)
+
+
+def test_store_failure_label_roundtrip(store):
+    """store_failure_label returns a non-None integer row ID."""
+    with patch.object(_mod, "get_current_cluster_id", return_value="test-cluster"):
+        label = {
+            "failure_type": "crash",
+            "severity": "high",
+            "namespace": "test-ns",
+            "resource_name": "test-pod-abc",
+            "resource_type": "pod",
+            "failure_time": datetime.now().isoformat(),
+            "detection_source": "test",
+            "error_category": "crash",
+        }
+        row_id = store.store_failure_label(label)
+        assert row_id is not None
+        assert isinstance(row_id, int)
+
+
+def test_get_statistics_returns_expected_keys(store):
+    """get_statistics() returns a dict with the essential keys."""
+    with patch.object(_mod, "get_current_cluster_id", return_value="test-cluster"):
+        stats = store.get_statistics()
+        assert isinstance(stats, dict)
+        for key in ("total_log_samples", "total_failure_labels", "total_training_runs"):
+            assert key in stats, f"Missing key: {key}"
+
+
+def test_get_training_data_returns_tuple(store):
+    """get_training_data() returns a (list, int) tuple."""
+    result = store.get_training_data()
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    samples, count = result
+    assert isinstance(samples, list)
+    assert isinstance(count, int)
+
+
+def test_record_training_run_returns_positive_id(store):
+    """record_training_run returns a positive integer run ID."""
+    run_id = store.record_training_run(
+        model_id="model-v1",
+        samples_used=100,
+        labels_used=50,
+        performance_metrics={"accuracy": 0.95},
+        trigger_reason="test",
+    )
+    assert isinstance(run_id, int)
+    assert run_id > 0
+
+
+def test_cleanup_old_data_returns_int(store):
+    """cleanup_old_data returns an int >= 0."""
+    deleted = store.cleanup_old_data(max_age_days=0)
+    assert isinstance(deleted, int)
+    assert deleted >= 0
+
+
+def test_get_failure_labels_in_window_returns_list(store):
+    """get_failure_labels_in_window returns a list."""
+    with patch.object(_mod, "get_current_cluster_id", return_value="test-cluster"):
+        now = datetime.now()
+        result = store.get_failure_labels_in_window(
+            start_time=now - timedelta(hours=1),
+            end_time=now,
+        )
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Source-level invariant: single conn.close() in the class
+# ---------------------------------------------------------------------------
+
+
+def test_single_conn_close_in_class_source():
+    """Only _get_connection's finally block should contain conn.close().
+
+    After the refactor, every public method delegates closing to
+    _get_connection's context manager, so the literal string 'conn.close()'
+    should appear exactly once in the TrainingDataStore source.
+    """
+    # Read the source file directly because inspect.getsource() cannot
+    # resolve modules loaded via importlib.util.spec_from_file_location.
+    full_source = _ML_PERSISTENCE_PATH.read_text()
+
+    # Extract only the TrainingDataStore class body (from 'class TrainingDataStore'
+    # to the next top-level class or end of file).
+    class_start = full_source.find("class TrainingDataStore")
+    assert class_start != -1, "Could not find TrainingDataStore in source"
+
+    # Find the next top-level class definition after TrainingDataStore
+    rest = full_source[class_start + len("class TrainingDataStore"):]
+    next_class = rest.find("\nclass ")
+    if next_class != -1:
+        class_source = full_source[class_start:class_start + len("class TrainingDataStore") + next_class]
+    else:
+        class_source = full_source[class_start:]
+
+    count = class_source.count("conn.close()")
+    assert count == 1, (
+        f"Expected exactly 1 occurrence of conn.close() in TrainingDataStore "
+        f"(inside _get_connection's finally block), but found {count}"
+    )


### PR DESCRIPTION
## Motivation

Issue #130 identified that `TrainingDataStore._get_connection()` returns a raw
`sqlite3.Connection` that callers must manually close. Every method follows the
pattern `conn = self._get_connection(); ...; conn.close()` — if any operation
raises between those two calls, the connection leaks. This affects all eight
public methods plus `_init_database`, and can cause locked database files or
file-descriptor exhaustion in long-running processes.

## Changes

- **`src/helpers/ml_persistence.py`** — Converted `_get_connection()` into a
  `@contextmanager` that wraps `sqlite3.connect()` in a `try/finally` block,
  guaranteeing `conn.close()` runs regardless of exceptions. Refactored every
  caller (`_init_database`, `store_log_sample`, `store_failure_label`,
  `get_training_data`, `get_failure_labels_in_window`, `get_statistics`,
  `record_training_run`, `cleanup_old_data`) to use
  `with self._get_connection() as conn:` instead of manual open/close.

- **`tests/test_ml_persistence_connection.py`** — Added 12 new tests covering:
  - `_get_connection` context-manager behaviour (yields live connection, closes
    on normal exit, closes on exception, propagates exceptions)
  - Public method roundtrips (`store_log_sample`, `store_failure_label`,
    `get_statistics`, `get_training_data`, `record_training_run`,
    `cleanup_old_data`, `get_failure_labels_in_window`)
  - Source-level invariant asserting `conn.close()` appears exactly once in the
    `TrainingDataStore` class

- **`pyproject.toml`** — Added `[tool.hatch.metadata] allow-direct-references = true`
  to unblock editable installs.

## Testing evidence

All 12 new tests pass locally with `pytest tests/test_ml_persistence_connection.py`:

| Test | Status |
|------|--------|
| `test_yields_live_sqlite_connection` | PASS |
| `test_closes_connection_on_normal_exit` | PASS |
| `test_closes_connection_on_exception` | PASS |
| `test_exception_propagates_through_context_manager` | PASS |
| `test_get_connection_returns_context_manager` | PASS |
| `test_store_log_sample_roundtrip` | PASS |
| `test_store_failure_label_roundtrip` | PASS |
| `test_get_statistics_returns_expected_keys` | PASS |
| `test_get_training_data_returns_tuple` | PASS |
| `test_record_training_run_returns_positive_id` | PASS |
| `test_cleanup_old_data_returns_int` | PASS |
| `test_get_failure_labels_in_window_returns_list` | PASS |
| `test_single_conn_close_in_class_source` | PASS |

Fixes #130