### PR TITLE
fix: port-forward subprocess resource leak in kubearchive integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,33 @@ KubeArchive authentication uses the following priority chain:
 4. OpenShift `oc whoami -t` token (for OpenShift clusters)
 5. Auto-created short-lived service account token (`kubectl create token`, 1-hour duration, Kubernetes only)
 
+### Resource Management & Cleanup
+
+The `KubeArchiveEndpointDiscovery` class implements robust subprocess cleanup for `kubectl port-forward` processes to prevent resource leaks.
+
+**Recommended Usage: Context Manager**
+
+Use the `with` statement for deterministic cleanup:
+
+```python
+from src.helpers.kubearchive_integration import KubeArchiveEndpointDiscovery
+
+with KubeArchiveEndpointDiscovery(k8s_core_api, k8s_custom_api) as discovery:
+    endpoint = await discovery.discover_endpoint()
+    # Use the endpoint...
+    # Port-forward subprocess automatically cleaned up on exit
+```
+
+**Automatic Cleanup Layers**
+
+When used without explicit context management, the class provides three fallback cleanup mechanisms:
+
+1. **`atexit` handler** — Cleans up port-forward on normal interpreter shutdown
+2. **Signal handlers (`SIGTERM`/`SIGINT`)** — Graceful cleanup on termination, chains to original handlers
+3. **`__del__` finalizer** — Last-resort fallback (not guaranteed timing)
+
+The context manager approach is preferred for deterministic resource cleanup.
+
 ### KubeArchive Configuration
 
 See the [Configuration](#configuration) section above for `KUBEARCHIVE_HOST` and `KUBEARCHIVE_ENABLED` environment variables.

--- a/src/helpers/kubearchive_integration.py
+++ b/src/helpers/kubearchive_integration.py
@@ -569,8 +569,14 @@ class KubeArchiveEndpointDiscovery:
             logger.error(f"Error setting up port-forward: {e}")
             return None
 
-    def stop_port_forward(self) -> None:
-        """Stop the port-forward process if running."""
+    def stop_port_forward(self, _from_signal_handler: bool = False) -> None:
+        """
+        Stop the port-forward process if running.
+
+        Args:
+            _from_signal_handler: Internal flag indicating call from signal handler.
+                When True, skips signal handler restoration to prevent dual execution.
+        """
         if self._port_forward_process:
             try:
                 logger.info("Stopping port-forward...")
@@ -587,7 +593,7 @@ class KubeArchiveEndpointDiscovery:
                 self._port_forward_process = None
                 self._port_forward_port = None
 
-        self._unregister_cleanup_handlers()
+        self._unregister_cleanup_handlers(restore_signal_handlers=not _from_signal_handler)
 
     def _register_cleanup_handlers(self) -> None:
         """Register atexit and signal handlers for cleanup."""
@@ -598,13 +604,24 @@ class KubeArchiveEndpointDiscovery:
         if not self._signal_handlers_registered:
             try:
                 self._original_sigterm_handler = signal.signal(signal.SIGTERM, self._signal_handler)
-                self._original_sigint_handler = signal.signal(signal.SIGINT, self._signal_handler)
-                self._signal_handlers_registered = True
+                try:
+                    self._original_sigint_handler = signal.signal(signal.SIGINT, self._signal_handler)
+                    self._signal_handlers_registered = True
+                except (ValueError, OSError) as e:
+                    # Rollback SIGTERM handler if SIGINT registration failed
+                    signal.signal(signal.SIGTERM, self._original_sigterm_handler)
+                    logger.debug(f"Could not register SIGINT handler (rolling back SIGTERM): {e}")
             except (ValueError, OSError) as e:
                 logger.debug(f"Could not register signal handlers: {e}")
 
-    def _unregister_cleanup_handlers(self) -> None:
-        """Unregister atexit and signal handlers."""
+    def _unregister_cleanup_handlers(self, restore_signal_handlers: bool = True) -> None:
+        """
+        Unregister atexit and signal handlers.
+
+        Args:
+            restore_signal_handlers: If True, restore original signal handlers.
+                Set to False when called from signal handler to prevent dual execution.
+        """
         if self._atexit_registered:
             try:
                 atexit.unregister(self.stop_port_forward)
@@ -612,7 +629,7 @@ class KubeArchiveEndpointDiscovery:
             except Exception as e:
                 logger.debug(f"Error unregistering atexit handler: {e}")
 
-        if self._signal_handlers_registered:
+        if self._signal_handlers_registered and restore_signal_handlers:
             try:
                 if self._original_sigterm_handler is not None:
                     signal.signal(signal.SIGTERM, self._original_sigterm_handler)
@@ -621,20 +638,43 @@ class KubeArchiveEndpointDiscovery:
                 self._signal_handlers_registered = False
             except (ValueError, OSError) as e:
                 logger.debug(f"Error restoring signal handlers: {e}")
-
+        elif not restore_signal_handlers:
+            # Mark handlers as unregistered without restoring them
+            # (signal handler will restore them itself)
+            self._signal_handlers_registered = False
     def _signal_handler(self, signum: int, frame) -> None:
-        """Handle signals by cleaning up port-forward and calling original handler."""
-        logger.debug(f"Received signal {signum}, cleaning up port-forward")
-        self.stop_port_forward()
+        """
+        Handle signals by cleaning up port-forward and calling original handler.
 
-        # Call the original handler if it exists
+        Properly distinguishes between:
+        - signal.SIG_DFL (0, falsy but valid): restore default and re-raise signal
+        - signal.SIG_IGN (1): ignore signal after cleanup
+        - callable handler: chain to original handler
+
+        IMPORTANT: Calls stop_port_forward with _from_signal_handler=True to prevent
+        dual handler execution (restore + explicit call).
+        """
+        logger.debug(f"Received signal {signum}, cleaning up port-forward")
+        self.stop_port_forward(_from_signal_handler=True)
+
+        # Determine the original handler based on signal type
         original_handler = None
         if signum == signal.SIGTERM:
             original_handler = self._original_sigterm_handler
         elif signum == signal.SIGINT:
             original_handler = self._original_sigint_handler
 
-        if original_handler and callable(original_handler):
+        # Handle different original handler types
+        # CRITICAL: signal.SIG_DFL is 0 (falsy), so we must use identity check
+        if original_handler is signal.SIG_DFL:
+            # Restore default handler and re-raise signal to terminate process
+            signal.signal(signum, signal.SIG_DFL)
+            os.kill(os.getpid(), signum)
+        elif original_handler is signal.SIG_IGN:
+            # Original handler was SIG_IGN, do nothing after cleanup
+            pass
+        elif callable(original_handler):
+            # Chain to original callable handler
             original_handler(signum, frame)
 
     def __enter__(self):

--- a/src/helpers/kubearchive_integration.py
+++ b/src/helpers/kubearchive_integration.py
@@ -19,6 +19,9 @@ import tempfile
 import subprocess
 import socket
 import yaml
+import re
+import atexit
+import signal
 from typing import Dict, List, Optional, Any, Tuple, Union
 from datetime import datetime
 from kubernetes import client
@@ -112,6 +115,10 @@ class KubeArchiveEndpointDiscovery:
         self._port_forward_port: Optional[int] = None
         self._discovered_namespace: Optional[str] = None
         self._discovered_port: Optional[int] = None
+        self._atexit_registered = False
+        self._signal_handlers_registered = False
+        self._original_sigterm_handler = None
+        self._original_sigint_handler = None
 
     async def discover_endpoint(self, force_refresh: bool = False) -> Optional[str]:
         """
@@ -548,6 +555,9 @@ class KubeArchiveEndpointDiscovery:
             self._port_forward_port = local_port
             local_endpoint = f"{protocol}://localhost:{local_port}"
 
+            # Register cleanup handlers
+            self._register_cleanup_handlers()
+
             logger.info(f"✓ Port-forward established: {local_endpoint} -> {in_cluster_endpoint}")
             return local_endpoint
 
@@ -577,8 +587,67 @@ class KubeArchiveEndpointDiscovery:
                 self._port_forward_process = None
                 self._port_forward_port = None
 
+        self._unregister_cleanup_handlers()
+
+    def _register_cleanup_handlers(self) -> None:
+        """Register atexit and signal handlers for cleanup."""
+        if not self._atexit_registered:
+            atexit.register(self.stop_port_forward)
+            self._atexit_registered = True
+
+        if not self._signal_handlers_registered:
+            try:
+                self._original_sigterm_handler = signal.signal(signal.SIGTERM, self._signal_handler)
+                self._original_sigint_handler = signal.signal(signal.SIGINT, self._signal_handler)
+                self._signal_handlers_registered = True
+            except (ValueError, OSError) as e:
+                logger.debug(f"Could not register signal handlers: {e}")
+
+    def _unregister_cleanup_handlers(self) -> None:
+        """Unregister atexit and signal handlers."""
+        if self._atexit_registered:
+            try:
+                atexit.unregister(self.stop_port_forward)
+                self._atexit_registered = False
+            except Exception as e:
+                logger.debug(f"Error unregistering atexit handler: {e}")
+
+        if self._signal_handlers_registered:
+            try:
+                if self._original_sigterm_handler is not None:
+                    signal.signal(signal.SIGTERM, self._original_sigterm_handler)
+                if self._original_sigint_handler is not None:
+                    signal.signal(signal.SIGINT, self._original_sigint_handler)
+                self._signal_handlers_registered = False
+            except (ValueError, OSError) as e:
+                logger.debug(f"Error restoring signal handlers: {e}")
+
+    def _signal_handler(self, signum: int, frame) -> None:
+        """Handle signals by cleaning up port-forward and calling original handler."""
+        logger.debug(f"Received signal {signum}, cleaning up port-forward")
+        self.stop_port_forward()
+
+        # Call the original handler if it exists
+        original_handler = None
+        if signum == signal.SIGTERM:
+            original_handler = self._original_sigterm_handler
+        elif signum == signal.SIGINT:
+            original_handler = self._original_sigint_handler
+
+        if original_handler and callable(original_handler):
+            original_handler(signum, frame)
+
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit: stop port-forward process."""
+        self.stop_port_forward()
+        return False
+
     def __del__(self):
-        """Cleanup: stop port-forward process."""
+        """Cleanup: stop port-forward process (last resort fallback)."""
         self.stop_port_forward()
 
     def clear_cache(self) -> None:

--- a/tests/test_port_forward_cleanup.py
+++ b/tests/test_port_forward_cleanup.py
@@ -1,0 +1,292 @@
+"""
+Tests for issue #121: Port-forward subprocess resource leak in KubeArchiveEndpointDiscovery.
+
+These tests verify:
+- The class implements context manager protocol (__enter__/__exit__)
+- The class registers atexit handler when starting port-forward
+- The class registers signal handlers (SIGTERM/SIGINT) for graceful shutdown
+- The cleanup handlers are unregistered in stop_port_forward
+- __del__ remains as a last-resort fallback
+"""
+
+import ast
+import os
+import re
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODULE_FILE = os.path.join(REPO_ROOT, "src", "helpers", "kubearchive_integration.py")
+
+if not os.path.isfile(MODULE_FILE):
+    raise FileNotFoundError(
+        f"Source file not found at {MODULE_FILE}. "
+        f"If the test file was moved, update the REPO_ROOT derivation."
+    )
+
+
+def _read_source():
+    """Read the kubearchive_integration.py source file."""
+    with open(MODULE_FILE, "r") as f:
+        return f.read()
+
+
+def _parse_ast():
+    """Parse the kubearchive_integration.py file into an AST."""
+    source = _read_source()
+    return ast.parse(source)
+
+
+def _find_class_node(tree, name="KubeArchiveEndpointDiscovery"):
+    """Find the AST node for a class definition by name."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    return None
+
+
+def _find_method_in_class(class_node, method_name):
+    """Find a method definition within a class node."""
+    for node in class_node.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == method_name:
+                return node
+    return None
+
+
+def _extract_method_source_lines(source, class_name, method_name):
+    """Extract source lines belonging to a method.
+
+    Returns (start_line, end_line, lines) where lines is a list of
+    source lines within the method (1-indexed start/end).
+    """
+    tree = ast.parse(source)
+    class_node = _find_class_node(tree, class_name)
+    if class_node is None:
+        return None, None, []
+    method_node = _find_method_in_class(class_node, method_name)
+    if method_node is None:
+        return None, None, []
+    start = method_node.lineno
+    end = method_node.end_lineno
+    all_lines = source.splitlines()
+    return start, end, all_lines[start - 1 : end]
+
+
+class TestRequiredImports:
+    """Verify required modules are imported."""
+
+    def test_atexit_imported(self):
+        """The file must import atexit."""
+        source = _read_source()
+        assert "import atexit" in source, "atexit is not imported"
+
+    def test_signal_imported(self):
+        """The file must import signal."""
+        source = _read_source()
+        assert "import signal" in source, "signal is not imported"
+
+    def test_re_imported(self):
+        """The file must import re (needed for _check_kubeconfig_route_inference)."""
+        source = _read_source()
+        assert "import re" in source, "re is not imported"
+
+
+class TestContextManager:
+    """Verify the class implements context manager protocol."""
+
+    def test_enter_method_exists(self):
+        """The class must have __enter__ method."""
+        tree = _parse_ast()
+        class_node = _find_class_node(tree)
+        assert class_node is not None, "KubeArchiveEndpointDiscovery class not found"
+        enter_method = _find_method_in_class(class_node, "__enter__")
+        assert enter_method is not None, "__enter__ method not found"
+
+    def test_exit_method_exists(self):
+        """The class must have __exit__ method."""
+        tree = _parse_ast()
+        class_node = _find_class_node(tree)
+        assert class_node is not None, "KubeArchiveEndpointDiscovery class not found"
+        exit_method = _find_method_in_class(class_node, "__exit__")
+        assert exit_method is not None, "__exit__ method not found"
+
+    def test_exit_calls_stop_port_forward(self):
+        """__exit__ must call stop_port_forward()."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(source, "KubeArchiveEndpointDiscovery", "__exit__")
+        assert lines, "__exit__ method source not found"
+        method_text = "\n".join(lines)
+        assert "stop_port_forward" in method_text, "__exit__ does not call stop_port_forward"
+
+    def test_enter_returns_self(self):
+        """__enter__ should return self."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(source, "KubeArchiveEndpointDiscovery", "__enter__")
+        assert lines, "__enter__ method source not found"
+        method_text = "\n".join(lines)
+        assert "return self" in method_text, "__enter__ does not return self"
+
+
+class TestAtexitHandler:
+    """Verify atexit handler is registered and unregistered."""
+
+    def test_atexit_register_in_register_cleanup_handlers(self):
+        """_register_cleanup_handlers must call atexit.register(stop_port_forward)."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "_register_cleanup_handlers"
+        )
+        assert lines, "_register_cleanup_handlers method not found"
+        method_text = "\n".join(lines)
+        assert "atexit.register" in method_text, "atexit.register not called in _register_cleanup_handlers"
+        assert "stop_port_forward" in method_text, "stop_port_forward not passed to atexit.register"
+
+    def test_atexit_unregister_in_unregister_cleanup_handlers(self):
+        """_unregister_cleanup_handlers must call atexit.unregister(stop_port_forward)."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "_unregister_cleanup_handlers"
+        )
+        assert lines, "_unregister_cleanup_handlers method not found"
+        method_text = "\n".join(lines)
+        assert "atexit.unregister" in method_text, "atexit.unregister not called in _unregister_cleanup_handlers"
+
+    def test_register_cleanup_handlers_called_in_setup_port_forward(self):
+        """_setup_port_forward must call _register_cleanup_handlers after starting the process."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "_setup_port_forward"
+        )
+        assert lines, "_setup_port_forward method not found"
+        method_text = "\n".join(lines)
+        assert "_register_cleanup_handlers" in method_text, (
+            "_setup_port_forward does not call _register_cleanup_handlers"
+        )
+
+    def test_unregister_cleanup_handlers_called_in_stop_port_forward(self):
+        """stop_port_forward must call _unregister_cleanup_handlers."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "stop_port_forward"
+        )
+        assert lines, "stop_port_forward method not found"
+        method_text = "\n".join(lines)
+        assert "_unregister_cleanup_handlers" in method_text, (
+            "stop_port_forward does not call _unregister_cleanup_handlers"
+        )
+
+
+class TestSignalHandlers:
+    """Verify signal handlers are registered and restored."""
+
+    def test_signal_handler_method_exists(self):
+        """The class must have _signal_handler method."""
+        tree = _parse_ast()
+        class_node = _find_class_node(tree)
+        assert class_node is not None, "KubeArchiveEndpointDiscovery class not found"
+        handler_method = _find_method_in_class(class_node, "_signal_handler")
+        assert handler_method is not None, "_signal_handler method not found"
+
+    def test_signal_handler_calls_stop_port_forward(self):
+        """_signal_handler must call stop_port_forward."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "_signal_handler"
+        )
+        assert lines, "_signal_handler method not found"
+        method_text = "\n".join(lines)
+        assert "stop_port_forward" in method_text, "_signal_handler does not call stop_port_forward"
+
+    def test_signal_handlers_registered_for_sigterm_and_sigint(self):
+        """_register_cleanup_handlers must register handlers for SIGTERM and SIGINT."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "_register_cleanup_handlers"
+        )
+        assert lines, "_register_cleanup_handlers method not found"
+        method_text = "\n".join(lines)
+        assert "signal.SIGTERM" in method_text, "SIGTERM handler not registered"
+        assert "signal.SIGINT" in method_text, "SIGINT handler not registered"
+        assert "signal.signal" in method_text, "signal.signal not called"
+
+    def test_signal_handlers_restored_in_unregister(self):
+        """_unregister_cleanup_handlers must restore original signal handlers."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "_unregister_cleanup_handlers"
+        )
+        assert lines, "_unregister_cleanup_handlers method not found"
+        method_text = "\n".join(lines)
+        assert "signal.signal" in method_text, "signal.signal not called in _unregister_cleanup_handlers"
+        assert "_original_sigterm_handler" in method_text or "_original_sigint_handler" in method_text, (
+            "original signal handlers not restored"
+        )
+
+
+class TestInitFields:
+    """Verify __init__ initializes cleanup tracking fields."""
+
+    def test_init_has_atexit_registered_field(self):
+        """__init__ must initialize _atexit_registered field."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "__init__"
+        )
+        assert lines, "__init__ method not found"
+        method_text = "\n".join(lines)
+        assert "_atexit_registered" in method_text, "_atexit_registered field not initialized"
+
+    def test_init_has_signal_handlers_registered_field(self):
+        """__init__ must initialize _signal_handlers_registered field."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "__init__"
+        )
+        assert lines, "__init__ method not found"
+        method_text = "\n".join(lines)
+        assert "_signal_handlers_registered" in method_text, "_signal_handlers_registered field not initialized"
+
+    def test_init_has_original_handler_fields(self):
+        """__init__ must initialize fields for storing original signal handlers."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "__init__"
+        )
+        assert lines, "__init__ method not found"
+        method_text = "\n".join(lines)
+        assert "_original_sigterm_handler" in method_text, "_original_sigterm_handler field not initialized"
+        assert "_original_sigint_handler" in method_text, "_original_sigint_handler field not initialized"
+
+
+class TestDelMethodPreserved:
+    """Verify __del__ is preserved as last-resort fallback."""
+
+    def test_del_method_exists(self):
+        """The class must still have __del__ method."""
+        tree = _parse_ast()
+        class_node = _find_class_node(tree)
+        assert class_node is not None, "KubeArchiveEndpointDiscovery class not found"
+        del_method = _find_method_in_class(class_node, "__del__")
+        assert del_method is not None, "__del__ method not found"
+
+    def test_del_calls_stop_port_forward(self):
+        """__del__ must call stop_port_forward."""
+        source = _read_source()
+        _, _, lines = _extract_method_source_lines(
+            source, "KubeArchiveEndpointDiscovery", "__del__"
+        )
+        assert lines, "__del__ method not found"
+        method_text = "\n".join(lines)
+        assert "stop_port_forward" in method_text, "__del__ does not call stop_port_forward"
+
+
+class TestSyntaxValidity:
+    """Verify the file is syntactically valid."""
+
+    def test_ast_parse_succeeds(self):
+        """ast.parse must succeed without raising SyntaxError."""
+        source = _read_source()
+        try:
+            ast.parse(source)
+        except SyntaxError as e:
+            pytest.fail(f"SyntaxError in kubearchive_integration.py: {e}")

--- a/tests/test_port_forward_cleanup.py
+++ b/tests/test_port_forward_cleanup.py
@@ -1,292 +1,250 @@
 """
-Tests for issue #121: Port-forward subprocess resource leak in KubeArchiveEndpointDiscovery.
+Behavioral tests for issue #121: Port-forward subprocess resource leak in
+KubeArchiveEndpointDiscovery.
 
-These tests verify:
-- The class implements context manager protocol (__enter__/__exit__)
-- The class registers atexit handler when starting port-forward
-- The class registers signal handlers (SIGTERM/SIGINT) for graceful shutdown
-- The cleanup handlers are unregistered in stop_port_forward
-- __del__ remains as a last-resort fallback
+Unlike source-inspection tests, these exercise the real cleanup logic:
+context manager, atexit/signal handler registration and restoration, and
+signal chaining. They are written to fail on the original defects — most
+importantly the blocking bug where signal.SIG_DFL (integer 0, falsy) caused
+SIGTERM cleanup to run without the process ever terminating.
 """
 
-import ast
 import os
-import re
+import signal
+import sys
+from unittest import mock
+
 import pytest
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-MODULE_FILE = os.path.join(REPO_ROOT, "src", "helpers", "kubearchive_integration.py")
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
 
-if not os.path.isfile(MODULE_FILE):
-    raise FileNotFoundError(
-        f"Source file not found at {MODULE_FILE}. "
-        f"If the test file was moved, update the REPO_ROOT derivation."
+from src.helpers import kubearchive_integration
+from src.helpers.kubearchive_integration import KubeArchiveEndpointDiscovery
+
+
+def _make_discovery():
+    """Build an instance with mocked K8s clients and no auto port-forward."""
+    return KubeArchiveEndpointDiscovery(
+        mock.MagicMock(), mock.MagicMock(), auto_port_forward=False
     )
 
 
-def _read_source():
-    """Read the kubearchive_integration.py source file."""
-    with open(MODULE_FILE, "r") as f:
-        return f.read()
+@pytest.fixture(autouse=True)
+def preserve_signal_handlers():
+    """Snapshot and restore real SIGTERM/SIGINT dispositions around each test."""
+    orig_term = signal.getsignal(signal.SIGTERM)
+    orig_int = signal.getsignal(signal.SIGINT)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, orig_term)
+        signal.signal(signal.SIGINT, orig_int)
 
 
-def _parse_ast():
-    """Parse the kubearchive_integration.py file into an AST."""
-    source = _read_source()
-    return ast.parse(source)
+@pytest.fixture(autouse=True)
+def patched_atexit():
+    """Patch the module's atexit so tests never leak real exit handlers."""
+    with mock.patch.object(kubearchive_integration, "atexit") as patched:
+        yield patched
 
 
-def _find_class_node(tree, name="KubeArchiveEndpointDiscovery"):
-    """Find the AST node for a class definition by name."""
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name == name:
-            return node
-    return None
+class TestModuleImport:
+    """The helper module must import without side effects."""
 
+    def test_class_importable(self):
+        assert KubeArchiveEndpointDiscovery is not None
 
-def _find_method_in_class(class_node, method_name):
-    """Find a method definition within a class node."""
-    for node in class_node.body:
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            if node.name == method_name:
-                return node
-    return None
-
-
-def _extract_method_source_lines(source, class_name, method_name):
-    """Extract source lines belonging to a method.
-
-    Returns (start_line, end_line, lines) where lines is a list of
-    source lines within the method (1-indexed start/end).
-    """
-    tree = ast.parse(source)
-    class_node = _find_class_node(tree, class_name)
-    if class_node is None:
-        return None, None, []
-    method_node = _find_method_in_class(class_node, method_name)
-    if method_node is None:
-        return None, None, []
-    start = method_node.lineno
-    end = method_node.end_lineno
-    all_lines = source.splitlines()
-    return start, end, all_lines[start - 1 : end]
-
-
-class TestRequiredImports:
-    """Verify required modules are imported."""
-
-    def test_atexit_imported(self):
-        """The file must import atexit."""
-        source = _read_source()
-        assert "import atexit" in source, "atexit is not imported"
-
-    def test_signal_imported(self):
-        """The file must import signal."""
-        source = _read_source()
-        assert "import signal" in source, "signal is not imported"
-
-    def test_re_imported(self):
-        """The file must import re (needed for _check_kubeconfig_route_inference)."""
-        source = _read_source()
-        assert "import re" in source, "re is not imported"
+    def test_construction_does_not_start_port_forward(self):
+        d = _make_discovery()
+        assert d._port_forward_process is None
+        assert d._atexit_registered is False
+        assert d._signal_handlers_registered is False
 
 
 class TestContextManager:
-    """Verify the class implements context manager protocol."""
-
-    def test_enter_method_exists(self):
-        """The class must have __enter__ method."""
-        tree = _parse_ast()
-        class_node = _find_class_node(tree)
-        assert class_node is not None, "KubeArchiveEndpointDiscovery class not found"
-        enter_method = _find_method_in_class(class_node, "__enter__")
-        assert enter_method is not None, "__enter__ method not found"
-
-    def test_exit_method_exists(self):
-        """The class must have __exit__ method."""
-        tree = _parse_ast()
-        class_node = _find_class_node(tree)
-        assert class_node is not None, "KubeArchiveEndpointDiscovery class not found"
-        exit_method = _find_method_in_class(class_node, "__exit__")
-        assert exit_method is not None, "__exit__ method not found"
-
-    def test_exit_calls_stop_port_forward(self):
-        """__exit__ must call stop_port_forward()."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(source, "KubeArchiveEndpointDiscovery", "__exit__")
-        assert lines, "__exit__ method source not found"
-        method_text = "\n".join(lines)
-        assert "stop_port_forward" in method_text, "__exit__ does not call stop_port_forward"
+    """The class must behave as a context manager that cleans up on exit."""
 
     def test_enter_returns_self(self):
-        """__enter__ should return self."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(source, "KubeArchiveEndpointDiscovery", "__enter__")
-        assert lines, "__enter__ method source not found"
-        method_text = "\n".join(lines)
-        assert "return self" in method_text, "__enter__ does not return self"
+        d = _make_discovery()
+        with d as ctx:
+            assert ctx is d
+
+    def test_exit_stops_running_process(self):
+        d = _make_discovery()
+        proc = mock.MagicMock()
+        d._port_forward_process = proc
+        with d:
+            pass
+        proc.terminate.assert_called_once()
+        assert d._port_forward_process is None
+
+
+class TestStopPortForward:
+    """stop_port_forward must terminate the subprocess and clear state."""
+
+    def test_terminates_and_clears_process(self):
+        d = _make_discovery()
+        proc = mock.MagicMock()
+        d._port_forward_process = proc
+        d._port_forward_port = 8081
+        d.stop_port_forward()
+        proc.terminate.assert_called_once()
+        proc.wait.assert_called_once()
+        assert d._port_forward_process is None
+        assert d._port_forward_port is None
+
+    def test_kills_when_terminate_times_out(self):
+        d = _make_discovery()
+        proc = mock.MagicMock()
+        proc.wait.side_effect = Exception("terminate timeout")
+        d._port_forward_process = proc
+        d.stop_port_forward()
+        proc.kill.assert_called_once()
+        assert d._port_forward_process is None
+
+    def test_noop_when_no_process(self):
+        d = _make_discovery()
+        # Must not raise even though no port-forward was ever started.
+        d.stop_port_forward()
+        assert d._port_forward_process is None
 
 
 class TestAtexitHandler:
-    """Verify atexit handler is registered and unregistered."""
+    """atexit registration must be idempotent and reversible."""
 
-    def test_atexit_register_in_register_cleanup_handlers(self):
-        """_register_cleanup_handlers must call atexit.register(stop_port_forward)."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "_register_cleanup_handlers"
-        )
-        assert lines, "_register_cleanup_handlers method not found"
-        method_text = "\n".join(lines)
-        assert "atexit.register" in method_text, "atexit.register not called in _register_cleanup_handlers"
-        assert "stop_port_forward" in method_text, "stop_port_forward not passed to atexit.register"
+    def test_register_adds_atexit_handler(self, patched_atexit):
+        d = _make_discovery()
+        d._register_cleanup_handlers()
+        patched_atexit.register.assert_called_once_with(d.stop_port_forward)
+        assert d._atexit_registered is True
 
-    def test_atexit_unregister_in_unregister_cleanup_handlers(self):
-        """_unregister_cleanup_handlers must call atexit.unregister(stop_port_forward)."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "_unregister_cleanup_handlers"
-        )
-        assert lines, "_unregister_cleanup_handlers method not found"
-        method_text = "\n".join(lines)
-        assert "atexit.unregister" in method_text, "atexit.unregister not called in _unregister_cleanup_handlers"
+    def test_register_is_idempotent(self, patched_atexit):
+        d = _make_discovery()
+        d._register_cleanup_handlers()
+        d._register_cleanup_handlers()
+        assert patched_atexit.register.call_count == 1
 
-    def test_register_cleanup_handlers_called_in_setup_port_forward(self):
-        """_setup_port_forward must call _register_cleanup_handlers after starting the process."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "_setup_port_forward"
-        )
-        assert lines, "_setup_port_forward method not found"
-        method_text = "\n".join(lines)
-        assert "_register_cleanup_handlers" in method_text, (
-            "_setup_port_forward does not call _register_cleanup_handlers"
-        )
-
-    def test_unregister_cleanup_handlers_called_in_stop_port_forward(self):
-        """stop_port_forward must call _unregister_cleanup_handlers."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "stop_port_forward"
-        )
-        assert lines, "stop_port_forward method not found"
-        method_text = "\n".join(lines)
-        assert "_unregister_cleanup_handlers" in method_text, (
-            "stop_port_forward does not call _unregister_cleanup_handlers"
-        )
+    def test_stop_unregisters_atexit(self, patched_atexit):
+        d = _make_discovery()
+        d._register_cleanup_handlers()
+        d.stop_port_forward()
+        patched_atexit.unregister.assert_called_once_with(d.stop_port_forward)
+        assert d._atexit_registered is False
 
 
-class TestSignalHandlers:
-    """Verify signal handlers are registered and restored."""
+class TestSignalHandlerBehavior:
+    """The signal handler must clean up and then chain to the original handler."""
 
-    def test_signal_handler_method_exists(self):
-        """The class must have _signal_handler method."""
-        tree = _parse_ast()
-        class_node = _find_class_node(tree)
-        assert class_node is not None, "KubeArchiveEndpointDiscovery class not found"
-        handler_method = _find_method_in_class(class_node, "_signal_handler")
-        assert handler_method is not None, "_signal_handler method not found"
+    def test_sigterm_default_handler_reraises_signal(self):
+        """Finding #1 (blocking): SIG_DFL is falsy, but SIGTERM must still terminate.
 
-    def test_signal_handler_calls_stop_port_forward(self):
-        """_signal_handler must call stop_port_forward."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "_signal_handler"
-        )
-        assert lines, "_signal_handler method not found"
-        method_text = "\n".join(lines)
-        assert "stop_port_forward" in method_text, "_signal_handler does not call stop_port_forward"
+        The buggy version guarded chaining with `if handler and callable(handler)`,
+        so a default (SIG_DFL) handler was skipped and the process survived SIGTERM.
+        """
+        d = _make_discovery()
+        proc = mock.MagicMock()
+        d._port_forward_process = proc
+        d._original_sigterm_handler = signal.SIG_DFL
+        with mock.patch.object(kubearchive_integration.signal, "signal") as m_sig, \
+             mock.patch.object(kubearchive_integration.os, "kill") as m_kill, \
+             mock.patch.object(kubearchive_integration.os, "getpid", return_value=4242):
+            d._signal_handler(signal.SIGTERM, None)
+        proc.terminate.assert_called_once()
+        m_sig.assert_any_call(signal.SIGTERM, signal.SIG_DFL)
+        m_kill.assert_called_once_with(4242, signal.SIGTERM)
 
-    def test_signal_handlers_registered_for_sigterm_and_sigint(self):
-        """_register_cleanup_handlers must register handlers for SIGTERM and SIGINT."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "_register_cleanup_handlers"
-        )
-        assert lines, "_register_cleanup_handlers method not found"
-        method_text = "\n".join(lines)
-        assert "signal.SIGTERM" in method_text, "SIGTERM handler not registered"
-        assert "signal.SIGINT" in method_text, "SIGINT handler not registered"
-        assert "signal.signal" in method_text, "signal.signal not called"
+    def test_sig_ign_handler_is_not_reraised(self):
+        d = _make_discovery()
+        proc = mock.MagicMock()
+        d._port_forward_process = proc
+        d._original_sigterm_handler = signal.SIG_IGN
+        with mock.patch.object(kubearchive_integration.os, "kill") as m_kill:
+            d._signal_handler(signal.SIGTERM, None)
+        proc.terminate.assert_called_once()
+        m_kill.assert_not_called()
 
-    def test_signal_handlers_restored_in_unregister(self):
-        """_unregister_cleanup_handlers must restore original signal handlers."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "_unregister_cleanup_handlers"
-        )
-        assert lines, "_unregister_cleanup_handlers method not found"
-        method_text = "\n".join(lines)
-        assert "signal.signal" in method_text, "signal.signal not called in _unregister_cleanup_handlers"
-        assert "_original_sigterm_handler" in method_text or "_original_sigint_handler" in method_text, (
-            "original signal handlers not restored"
-        )
+    def test_callable_handler_is_chained(self):
+        d = _make_discovery()
+        proc = mock.MagicMock()
+        d._port_forward_process = proc
+        original = mock.MagicMock()
+        d._original_sigint_handler = original
+        frame = object()
+        d._signal_handler(signal.SIGINT, frame)
+        proc.terminate.assert_called_once()
+        original.assert_called_once_with(signal.SIGINT, frame)
 
 
-class TestInitFields:
-    """Verify __init__ initializes cleanup tracking fields."""
+class TestSignalRegistration:
+    """Signal handlers must be installed for both signals and restored on stop."""
 
-    def test_init_has_atexit_registered_field(self):
-        """__init__ must initialize _atexit_registered field."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "__init__"
-        )
-        assert lines, "__init__ method not found"
-        method_text = "\n".join(lines)
-        assert "_atexit_registered" in method_text, "_atexit_registered field not initialized"
+    def test_registers_sigterm_and_sigint(self):
+        d = _make_discovery()
+        d._register_cleanup_handlers()
+        # Bound methods compare equal but are not identical objects, so use ==.
+        assert signal.getsignal(signal.SIGTERM) == d._signal_handler
+        assert signal.getsignal(signal.SIGINT) == d._signal_handler
+        assert d._signal_handlers_registered is True
 
-    def test_init_has_signal_handlers_registered_field(self):
-        """__init__ must initialize _signal_handlers_registered field."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "__init__"
-        )
-        assert lines, "__init__ method not found"
-        method_text = "\n".join(lines)
-        assert "_signal_handlers_registered" in method_text, "_signal_handlers_registered field not initialized"
+    def test_sigint_failure_rolls_back_sigterm(self):
+        """Finding #2: if SIGINT registration fails, the SIGTERM handler must be
+        rolled back rather than left dangling with the flag still False."""
+        d = _make_discovery()
+        previous_sigterm = mock.MagicMock(name="previous_sigterm_handler")
+        calls = []
 
-    def test_init_has_original_handler_fields(self):
-        """__init__ must initialize fields for storing original signal handlers."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "__init__"
-        )
-        assert lines, "__init__ method not found"
-        method_text = "\n".join(lines)
-        assert "_original_sigterm_handler" in method_text, "_original_sigterm_handler field not initialized"
-        assert "_original_sigint_handler" in method_text, "_original_sigint_handler field not initialized"
+        def fake_signal(signum, handler):
+            calls.append((signum, handler))
+            if signum == signal.SIGINT:
+                raise ValueError("signal only works in main thread")
+            return previous_sigterm
+
+        with mock.patch.object(kubearchive_integration.signal, "signal", side_effect=fake_signal):
+            d._register_cleanup_handlers()
+
+        assert calls[0] == (signal.SIGTERM, d._signal_handler)
+        assert calls[1] == (signal.SIGINT, d._signal_handler)
+        assert calls[2] == (signal.SIGTERM, previous_sigterm)
+        assert d._signal_handlers_registered is False
 
 
-class TestDelMethodPreserved:
-    """Verify __del__ is preserved as last-resort fallback."""
+class TestFromSignalHandlerFlag:
+    """Finding #3: cleanup from within a signal handler must not re-restore
+    handlers, which would otherwise run the original handler twice."""
 
-    def test_del_method_exists(self):
-        """The class must still have __del__ method."""
-        tree = _parse_ast()
-        class_node = _find_class_node(tree)
-        assert class_node is not None, "KubeArchiveEndpointDiscovery class not found"
-        del_method = _find_method_in_class(class_node, "__del__")
-        assert del_method is not None, "__del__ method not found"
+    def test_stop_from_signal_handler_skips_restoration(self):
+        d = _make_discovery()
+        d._signal_handlers_registered = True
+        d._original_sigterm_handler = mock.MagicMock()
+        d._original_sigint_handler = mock.MagicMock()
+        with mock.patch.object(kubearchive_integration.signal, "signal") as m_sig:
+            d.stop_port_forward(_from_signal_handler=True)
+        m_sig.assert_not_called()
+        assert d._signal_handlers_registered is False
 
-    def test_del_calls_stop_port_forward(self):
-        """__del__ must call stop_port_forward."""
-        source = _read_source()
-        _, _, lines = _extract_method_source_lines(
-            source, "KubeArchiveEndpointDiscovery", "__del__"
-        )
-        assert lines, "__del__ method not found"
-        method_text = "\n".join(lines)
-        assert "stop_port_forward" in method_text, "__del__ does not call stop_port_forward"
+    def test_stop_default_restores_signal_handlers(self):
+        d = _make_discovery()
+        d._signal_handlers_registered = True
+        term = mock.MagicMock()
+        intr = mock.MagicMock()
+        d._original_sigterm_handler = term
+        d._original_sigint_handler = intr
+        with mock.patch.object(kubearchive_integration.signal, "signal") as m_sig:
+            d.stop_port_forward()
+        m_sig.assert_any_call(signal.SIGTERM, term)
+        m_sig.assert_any_call(signal.SIGINT, intr)
+        assert d._signal_handlers_registered is False
 
 
-class TestSyntaxValidity:
-    """Verify the file is syntactically valid."""
+class TestDelFallback:
+    """__del__ must remain a last-resort cleanup path."""
 
-    def test_ast_parse_succeeds(self):
-        """ast.parse must succeed without raising SyntaxError."""
-        source = _read_source()
-        try:
-            ast.parse(source)
-        except SyntaxError as e:
-            pytest.fail(f"SyntaxError in kubearchive_integration.py: {e}")
+    def test_del_stops_process(self):
+        d = _make_discovery()
+        proc = mock.MagicMock()
+        d._port_forward_process = proc
+        d.__del__()
+        proc.terminate.assert_called_once()
+        assert d._port_forward_process is None

--- a/tests/test_port_forward_cleanup_behavior.py
+++ b/tests/test_port_forward_cleanup_behavior.py
@@ -1,0 +1,360 @@
+"""
+Behavioral tests for port-forward subprocess cleanup in KubeArchiveEndpointDiscovery.
+
+Verifies that:
+1. Context manager calls stop_port_forward on exit (normal and exception).
+2. atexit handler is registered/unregistered correctly.
+3. Signal handlers are installed, chain to originals, and are restored.
+4. stop_port_forward is idempotent (safe to call multiple times).
+5. _register_cleanup_handlers is idempotent (only registers once).
+"""
+
+import atexit
+import importlib.util
+import os
+import signal
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Direct-import of kubearchive_integration.py, mocking kubernetes at load time
+# ---------------------------------------------------------------------------
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+
+_KA_PATH = SRC_DIR / "helpers" / "kubearchive_integration.py"
+
+# Create mock kubernetes modules before importing the real module
+_mock_k8s = MagicMock()
+_mock_k8s_client = MagicMock()
+_mock_k8s.client = _mock_k8s_client
+_mock_k8s_rest = MagicMock()
+
+_patches = {
+    "kubernetes": _mock_k8s,
+    "kubernetes.client": _mock_k8s_client,
+    "kubernetes.client.rest": _mock_k8s_rest,
+    "aiohttp": MagicMock(),
+}
+
+for mod_name, mock_obj in _patches.items():
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = mock_obj
+
+try:
+    _spec = importlib.util.spec_from_file_location(
+        "helpers.kubearchive_integration", _KA_PATH
+    )
+    _mod: ModuleType = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+    KubeArchiveEndpointDiscovery = _mod.KubeArchiveEndpointDiscovery
+except (ImportError, ModuleNotFoundError, FileNotFoundError) as _imp_err:
+    pytest.skip(
+        f"Cannot import KubeArchiveEndpointDiscovery: {_imp_err}",
+        allow_module_level=True,
+    )
+
+
+def _make_discovery(**kwargs):
+    """Create a KubeArchiveEndpointDiscovery with mocked k8s clients."""
+    return KubeArchiveEndpointDiscovery(
+        k8s_core_api=MagicMock(),
+        k8s_custom_api=MagicMock(),
+        **kwargs,
+    )
+
+
+def _make_discovery_with_fake_process():
+    """Create a discovery instance with a fake port-forward process attached."""
+    d = _make_discovery()
+    proc = MagicMock()
+    proc.terminate = MagicMock()
+    proc.wait = MagicMock()
+    proc.kill = MagicMock()
+    d._port_forward_process = proc
+    d._port_forward_port = 8081
+    return d, proc
+
+
+# ---------------------------------------------------------------------------
+# Context manager tests
+# ---------------------------------------------------------------------------
+
+class TestContextManagerBehavior:
+
+    def test_enter_returns_same_instance(self):
+        d = _make_discovery()
+        result = d.__enter__()
+        assert result is d
+
+    def test_exit_calls_stop_port_forward(self):
+        d = _make_discovery()
+        d.stop_port_forward = MagicMock()
+        d.__exit__(None, None, None)
+        d.stop_port_forward.assert_called_once()
+
+    def test_with_statement_calls_cleanup(self):
+        d = _make_discovery()
+        d.stop_port_forward = MagicMock()
+        with d:
+            pass
+        d.stop_port_forward.assert_called_once()
+
+    def test_with_statement_calls_cleanup_on_exception(self):
+        d = _make_discovery()
+        d.stop_port_forward = MagicMock()
+        with pytest.raises(ValueError):
+            with d:
+                raise ValueError("test error")
+        d.stop_port_forward.assert_called_once()
+
+    def test_exit_does_not_suppress_exceptions(self):
+        d = _make_discovery()
+        result = d.__exit__(ValueError, ValueError("x"), None)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# stop_port_forward tests
+# ---------------------------------------------------------------------------
+
+class TestStopPortForward:
+
+    def test_terminates_running_process(self):
+        d, proc = _make_discovery_with_fake_process()
+        d.stop_port_forward()
+        proc.terminate.assert_called_once()
+        proc.wait.assert_called_once_with(timeout=5)
+
+    def test_clears_process_and_port(self):
+        d, _ = _make_discovery_with_fake_process()
+        d.stop_port_forward()
+        assert d._port_forward_process is None
+        assert d._port_forward_port is None
+
+    def test_idempotent_no_process(self):
+        d = _make_discovery()
+        assert d._port_forward_process is None
+        d.stop_port_forward()
+        d.stop_port_forward()
+
+    def test_kills_process_on_terminate_timeout(self):
+        d, proc = _make_discovery_with_fake_process()
+        proc.wait.side_effect = Exception("timeout")
+        d.stop_port_forward()
+        proc.kill.assert_called_once()
+
+    def test_unregisters_cleanup_handlers(self):
+        d, _ = _make_discovery_with_fake_process()
+        d._unregister_cleanup_handlers = MagicMock()
+        d.stop_port_forward()
+        d._unregister_cleanup_handlers.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# atexit handler tests
+# ---------------------------------------------------------------------------
+
+class TestAtexitRegistration:
+
+    def test_register_sets_flag(self):
+        d = _make_discovery()
+        assert d._atexit_registered is False
+        with patch("atexit.register") as mock_reg:
+            d._register_cleanup_handlers()
+        assert d._atexit_registered is True
+        mock_reg.assert_called_once_with(d.stop_port_forward)
+
+    def test_register_is_idempotent(self):
+        d = _make_discovery()
+        with patch("atexit.register") as mock_reg:
+            d._register_cleanup_handlers()
+            d._register_cleanup_handlers()
+        mock_reg.assert_called_once()
+
+    def test_unregister_clears_flag(self):
+        d = _make_discovery()
+        d._atexit_registered = True
+        with patch("atexit.unregister") as mock_unreg:
+            d._unregister_cleanup_handlers()
+        assert d._atexit_registered is False
+        mock_unreg.assert_called_once_with(d.stop_port_forward)
+
+    def test_unregister_noop_when_not_registered(self):
+        d = _make_discovery()
+        assert d._atexit_registered is False
+        with patch("atexit.unregister") as mock_unreg:
+            d._unregister_cleanup_handlers()
+        mock_unreg.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Signal handler tests
+# ---------------------------------------------------------------------------
+
+class TestSignalHandlerRegistration:
+
+    def test_register_installs_sigterm_and_sigint(self):
+        d = _make_discovery()
+        original_term = signal.getsignal(signal.SIGTERM)
+        original_int = signal.getsignal(signal.SIGINT)
+        try:
+            d._register_cleanup_handlers()
+            assert d._signal_handlers_registered is True
+            assert signal.getsignal(signal.SIGTERM) == d._signal_handler
+            assert signal.getsignal(signal.SIGINT) == d._signal_handler
+        finally:
+            signal.signal(signal.SIGTERM, original_term)
+            signal.signal(signal.SIGINT, original_int)
+
+    def test_register_saves_original_handlers(self):
+        d = _make_discovery()
+        original_term = signal.getsignal(signal.SIGTERM)
+        original_int = signal.getsignal(signal.SIGINT)
+        try:
+            d._register_cleanup_handlers()
+            assert d._original_sigterm_handler == original_term
+            assert d._original_sigint_handler == original_int
+        finally:
+            signal.signal(signal.SIGTERM, original_term)
+            signal.signal(signal.SIGINT, original_int)
+
+    def test_register_is_idempotent(self):
+        d = _make_discovery()
+        original_term = signal.getsignal(signal.SIGTERM)
+        original_int = signal.getsignal(signal.SIGINT)
+        try:
+            d._register_cleanup_handlers()
+            d._register_cleanup_handlers()
+            assert d._original_sigterm_handler == original_term
+            assert d._original_sigint_handler == original_int
+        finally:
+            signal.signal(signal.SIGTERM, original_term)
+            signal.signal(signal.SIGINT, original_int)
+
+    def test_unregister_restores_original_handlers(self):
+        d = _make_discovery()
+        original_term = signal.getsignal(signal.SIGTERM)
+        original_int = signal.getsignal(signal.SIGINT)
+        try:
+            d._register_cleanup_handlers()
+            d._unregister_cleanup_handlers()
+            assert d._signal_handlers_registered is False
+            assert signal.getsignal(signal.SIGTERM) == original_term
+            assert signal.getsignal(signal.SIGINT) == original_int
+        finally:
+            signal.signal(signal.SIGTERM, original_term)
+            signal.signal(signal.SIGINT, original_int)
+
+
+class TestSignalHandlerBehavior:
+
+    def test_signal_handler_calls_stop_port_forward(self):
+        d, _ = _make_discovery_with_fake_process()
+        d.stop_port_forward = MagicMock()
+        d._signal_handler(signal.SIGTERM, None)
+        d.stop_port_forward.assert_called_once()
+
+    def test_signal_handler_chains_to_original_sigterm(self):
+        d = _make_discovery()
+        original = MagicMock()
+        d._original_sigterm_handler = original
+        d._signal_handler(signal.SIGTERM, None)
+        original.assert_called_once_with(signal.SIGTERM, None)
+
+    def test_signal_handler_chains_to_original_sigint(self):
+        d = _make_discovery()
+        original = MagicMock()
+        d._original_sigint_handler = original
+        d._signal_handler(signal.SIGINT, None)
+        original.assert_called_once_with(signal.SIGINT, None)
+
+    def test_signal_handler_restores_sig_dfl_and_reraises(self):
+        """Test that SIG_DFL is properly restored and signal is re-raised."""
+        d = _make_discovery()
+        d._original_sigterm_handler = signal.SIG_DFL
+        original_term = signal.getsignal(signal.SIGTERM)
+        try:
+            with patch("os.kill") as mock_kill:
+                d._signal_handler(signal.SIGTERM, None)
+                # Should restore SIG_DFL and re-raise signal
+                assert signal.getsignal(signal.SIGTERM) == signal.SIG_DFL
+                mock_kill.assert_called_once()
+                call_args = mock_kill.call_args[0]
+                assert call_args[0] == os.getpid()
+                assert call_args[1] == signal.SIGTERM
+        finally:
+            signal.signal(signal.SIGTERM, original_term)
+
+    def test_signal_handler_ignores_sig_ign(self):
+        """Test that SIG_IGN is properly handled (ignored after cleanup)."""
+        d = _make_discovery()
+        d._original_sigterm_handler = signal.SIG_IGN
+        with patch("signal.signal") as mock_signal:
+            d._signal_handler(signal.SIGTERM, None)
+            # Should not restore or re-raise for SIG_IGN
+            mock_signal.assert_not_called()
+
+    def test_signal_handler_skips_none_original(self):
+        """Test that None original handler is handled gracefully."""
+        d = _make_discovery()
+        d._original_sigterm_handler = None
+        d._signal_handler(signal.SIGTERM, None)
+        # Should complete without error
+
+
+# ---------------------------------------------------------------------------
+# Full lifecycle integration
+# ---------------------------------------------------------------------------
+
+class TestFullCleanupLifecycle:
+
+    def test_register_then_stop_clears_everything(self):
+        d = _make_discovery()
+        original_term = signal.getsignal(signal.SIGTERM)
+        original_int = signal.getsignal(signal.SIGINT)
+        try:
+            d._register_cleanup_handlers()
+            assert d._atexit_registered is True
+            assert d._signal_handlers_registered is True
+
+            d.stop_port_forward()
+            assert d._atexit_registered is False
+            assert d._signal_handlers_registered is False
+        finally:
+            signal.signal(signal.SIGTERM, original_term)
+            signal.signal(signal.SIGINT, original_int)
+
+    def test_context_manager_with_process_full_cycle(self):
+        d, proc = _make_discovery_with_fake_process()
+        d._register_cleanup_handlers()
+        original_term = signal.getsignal(signal.SIGTERM)
+        original_int = signal.getsignal(signal.SIGINT)
+        try:
+            with d:
+                assert d._port_forward_process is proc
+            assert d._port_forward_process is None
+            assert d._port_forward_port is None
+            proc.terminate.assert_called_once()
+        finally:
+            signal.signal(signal.SIGTERM, original_term)
+            signal.signal(signal.SIGINT, original_int)
+
+
+# ---------------------------------------------------------------------------
+# Init field defaults
+# ---------------------------------------------------------------------------
+
+class TestInitDefaults:
+
+    def test_cleanup_fields_default_to_false_or_none(self):
+        d = _make_discovery()
+        assert d._atexit_registered is False
+        assert d._signal_handlers_registered is False
+        assert d._original_sigterm_handler is None
+        assert d._original_sigint_handler is None
+        assert d._port_forward_process is None
+        assert d._port_forward_port is None


### PR DESCRIPTION
## Summary

This changes handle port-forward subprocess resource leak by implementing context manager methods in KubeArchiveEndpointDiscovery class and registering atexit handler and signal handlers to cleanup the port forwarding in case of inappropriate process ending.

## Related Issue

Fixes #121

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New MCP tool (adds a new tool to the server)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Context manager (__enter__/__exit__) — deterministic cleanup via with statement
- atexit handler — registered when port-forward starts, unregistered in stop_port_forward() to avoid double cleanup
- Signal handlers (SIGTERM/SIGINT) — saves and restores original handlers, chains to them after cleanup

## New MCP Tool Checklist (if applicable)

If this PR adds a new MCP tool, ensure you followed the [Spec-Driven Development](docs/LUMINO_MCP_TOOL_DEVELOPMENT_GUIDE.md) process:

- [ ] Stage 1: Functional Specification created and reviewed
- [ ] Stage 2: Implementation Specification created and reviewed
- [ ] Stage 3: Code follows the implementation spec
- [ ] Tool is read-only (no cluster modifications)
- [ ] Tool has comprehensive docstring with Args and Returns
- [ ] Tool handles exceptions gracefully
- [ ] Tool added to README.md tool list

## Testing

Describe how you tested your changes:

- [ ] Tested locally with MCP client
- [ ] Tested with Kubernetes cluster
- [x] Added/updated unit tests
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know.
