### PR TITLE
feat: add .agents/ directory skeleton

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+Architecture overview for AI agents (Cursor, Codex, OpenCode, and other non-Claude-Code clients).
+
+<!-- Filled by SPRE-5969 -->

--- a/.agents/config/autonomy-levels.yaml
+++ b/.agents/config/autonomy-levels.yaml
@@ -1,0 +1,2 @@
+# Autonomy levels for agent actions (read-only, suggest, auto-remediate, etc.).
+# Placeholder — fill with actual autonomy configuration.

--- a/.agents/config/clusters.yaml
+++ b/.agents/config/clusters.yaml
@@ -1,0 +1,2 @@
+# Cluster inventory and access configuration.
+# Placeholder — fill with actual cluster definitions.

--- a/.agents/config/safety-guardrails.yaml
+++ b/.agents/config/safety-guardrails.yaml
@@ -1,0 +1,2 @@
+# Safety guardrails for agentic operations.
+# Placeholder — fill with actual guardrail policies.

--- a/.agents/programs/README.md
+++ b/.agents/programs/README.md
@@ -1,0 +1,3 @@
+# programs/
+
+Multi-step agentic programs that orchestrate skills and tools.

--- a/.agents/runbooks/README.md
+++ b/.agents/runbooks/README.md
@@ -1,0 +1,4 @@
+# runbooks/
+
+Machine-readable YAML runbooks for failure patterns.
+Each runbook defines trigger patterns, diagnostic steps, and remediation actions.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,3 @@
+# skills/
+
+Reusable agent skills for common SRE operations.

--- a/.agents/tests/evaluation/README.md
+++ b/.agents/tests/evaluation/README.md
@@ -1,0 +1,3 @@
+# evaluation/
+
+Agent evaluation harnesses and scoring scripts.

--- a/.agents/tests/fixtures/README.md
+++ b/.agents/tests/fixtures/README.md
@@ -1,0 +1,3 @@
+# fixtures/
+
+Static test fixtures (mock API responses, sample logs, etc.) for evaluation.


### PR DESCRIPTION
Implements the physical layout defined in ADR-006 (.agents/ co-located
with tools) per [SPRE-5968](https://redhat.atlassian.net/browse/SPRE-5968).

Adds placeholder files to track:
- skills/, programs/, runbooks/ directories
- config/ with safety-guardrails, autonomy-levels, clusters stubs
- tests/fixtures/ and tests/evaluation/ directories
- AGENTS.md entry point (content added in SPRE-5969)

Jira: [SPRE-5968](https://redhat.atlassian.net/browse/SPRE-5968)