### PR TITLE
feat(agents): add CLAUDE.md and AGENTS.md entry-point files for agent skill discovery

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,5 +1,136 @@
-# AGENTS.md
+# AGENTS.md — Lumino MCP Server: Agentic AI Architecture
 
-Architecture overview for AI agents (Cursor, Codex, OpenCode, and other non-Claude-Code clients).
+This file documents the `.agents/` system for AI clients other than Claude Code
+(Cursor, Codex, OpenCode, and any future agentic runtimes).
 
-<!-- Filled by SPRE-5969 -->
+For Claude Code-specific instructions, see `.agents/CLAUDE.md`.
+
+---
+
+## Overview
+
+The `.agents/` directory co-locates all agentic AI artefacts with the lumino MCP server tools
+they operate on (per ADR-006). It provides:
+
+- **Skills** — reusable, parameterised SRE investigation patterns
+- **Programs** — multi-step orchestration scripts that chain skills and tools
+- **Runbooks** — machine-readable YAML failure response guides
+- **Config** — safety guardrails, autonomy levels, and cluster inventory
+- **Tests** — evaluation harnesses and fixtures for validating agent behaviour
+
+---
+
+## Directory Layout
+
+```
+.agents/
+├── CLAUDE.md           # Claude Code system instructions (skill triggers, tool index, safety rules)
+├── AGENTS.md           # This file — architecture overview for all other clients
+│
+├── skills/             # Reusable investigation and remediation skills (Markdown)
+│   └── README.md
+│
+├── programs/           # Multi-step agentic programs that orchestrate skills + tools
+│   └── README.md
+│
+├── runbooks/           # Machine-readable YAML runbooks for known failure patterns
+│   └── README.md
+│
+├── config/
+│   ├── safety-guardrails.yaml   # Hard boundaries on autonomous actions
+│   ├── autonomy-levels.yaml     # What the agent may do vs. must escalate to a human
+│   └── clusters.yaml            # Cluster inventory and access context
+│
+└── tests/
+    ├── fixtures/        # Static mock data (API responses, logs) for offline evaluation
+    └── evaluation/      # Scoring harnesses for measuring agent diagnostic accuracy
+```
+
+---
+
+## MCP Tool Catalog
+
+All tools are exposed by the lumino MCP server (`src/server-mcp.py`) and are **strictly read-only**.
+No tool performs writes, deletes, or mutations on any cluster resource.
+
+### Categories
+
+| Category | Tools |
+|----------|-------|
+| Kubernetes Core | `list_namespaces`, `list_pods_in_namespace`, `get_kubernetes_resource`, `search_resources_by_labels`, `query_kubearchive` |
+| Tekton Pipelines | `list_pipelineruns`, `list_taskruns`, `get_pipelinerun_logs`, `list_recent_pipeline_runs`, `find_pipeline`, `get_tekton_pipeline_runs_status` |
+| Log Analysis | `analyze_logs`, `smart_summarize_pod_logs`, `stream_analyze_pod_logs`, `analyze_pod_logs_hybrid`, `detect_log_anomalies`, `semantic_log_search` |
+| Event Analysis | `smart_get_namespace_events`, `progressive_event_analysis`, `advanced_event_analytics` |
+| Failure Analysis & RCA | `analyze_failed_pipeline`, `automated_triage_rca_report_generator` |
+| Resource Monitoring | `check_resource_constraints`, `detect_anomalies`, `prometheus_query`, `resource_bottleneck_forecaster` |
+| Namespace Investigation | `conservative_namespace_overview`, `adaptive_namespace_investigation` |
+| Certificate & Security | `investigate_tls_certificate_issues`, `check_cluster_certificate_health` |
+| OpenShift Specific | `get_machine_config_pool_status`, `get_openshift_cluster_operator_status`, `get_etcd_logs` |
+| CI/CD Performance | `ci_cd_performance_baselining_tool`, `pipeline_tracer` |
+| Topology & Prediction | `live_system_topology_mapper`, `predictive_log_analyzer`, `manage_prediction_training_data` |
+| Simulation | `what_if_scenario_simulator` |
+
+Full tool parameter documentation is in `README.md` at the repository root.
+
+---
+
+## Skills
+
+Skills live in `.agents/skills/` as Markdown files. Each skill file defines:
+
+- **Trigger phrases** — natural language patterns that indicate when to apply this skill
+- **Inputs** — parameters the invoking agent must supply (namespace, pod name, time range, etc.)
+- **Steps** — ordered sequence of MCP tool calls with parameter templates
+- **Output** — what the skill produces (findings summary, hypothesis list, etc.)
+
+**Discovery:** list `.agents/skills/` and read the file whose trigger phrases match the user request.
+
+---
+
+## Runbooks
+
+Runbooks live in `.agents/runbooks/` as YAML files. Schema:
+
+```yaml
+name: <runbook-name>
+description: <one-line description>
+trigger_patterns:
+  - <log or event string that indicates this failure>
+diagnostic_steps:
+  - step: <human-readable step name>
+    tool: <mcp_tool_name>
+    params:
+      <param>: <value or template variable>
+    interpret: <what to look for in the output>
+remediation:
+  - <human-actionable step — never auto-applied by the agent>
+references:
+  - <doc or runbook URL>
+```
+
+**Execution:** read the runbook YAML, execute each `diagnostic_steps` entry using the named
+MCP tool with the given params, interpret the output per the `interpret` field, then present
+the `remediation` steps to the human operator for approval.
+
+---
+
+## Safety Contract
+
+All agents operating in this system must honour:
+
+1. **Read-only** — no writes, deletes, or mutations to cluster state.
+2. **Hypothesis framing** — findings are presented as hypotheses, not facts.
+3. **Human approval for remediation** — no autonomous remediation without explicit operator sign-off.
+4. **Guardrail compliance** — check `.agents/config/safety-guardrails.yaml` and
+   `.agents/config/autonomy-levels.yaml` before any action that could affect production.
+
+---
+
+## Supported Clients
+
+| Client | Entry point |
+|--------|------------|
+| Claude Code | `.agents/CLAUDE.md` (auto-discovered) |
+| Cursor | `.agents/AGENTS.md` (add to context manually or via `.cursorrules`) |
+| Codex / OpenAI Agents | `.agents/AGENTS.md` (pass as system context) |
+| OpenCode | `.agents/AGENTS.md` (reference in project config) |

--- a/.agents/CLAUDE.md
+++ b/.agents/CLAUDE.md
@@ -1,0 +1,181 @@
+# CLAUDE.md — Lumino MCP Server: Agent System Instructions
+
+These instructions apply to Claude Code when operating in the `lumino-mcp-server` repository.
+
+---
+
+## Role
+
+You are an SRE investigation assistant for Kubernetes, OpenShift, and Tekton environments.
+Your primary function is to help engineers diagnose, triage, and remediate production incidents
+using the lumino MCP tools — all of which are **read-only**.
+
+---
+
+## Core Operating Principles
+
+1. **All findings are hypotheses.** Never assert a root cause without evidence from tool output.
+   Present findings as: "This suggests…", "The data indicates…", not "The problem is…".
+
+2. **Recall memory before investigating.** Before running any diagnostic tool, check whether
+   a similar incident or pattern has been seen before. Use available memory tools to surface
+   prior findings, known issues, and past remediations.
+
+3. **Read-only on production.** Every lumino tool is strictly read-only. Never attempt to
+   patch, delete, restart, or modify any cluster resource. Remediation steps are recommendations
+   to the human operator — never executed autonomously.
+
+4. **Follow runbooks for known failure patterns.** Check `.agents/runbooks/` before
+   free-form investigation. If a runbook exists for the failure pattern, use it as the
+   diagnostic guide.
+
+5. **Escalate unknowns.** If investigation reaches a dead end or the data is ambiguous,
+   say so explicitly and propose the next human action.
+
+---
+
+## Available MCP Tools
+
+All tools are provided by the lumino MCP server. Use them for investigation only.
+
+### Kubernetes Core
+| Tool | Use for |
+|------|---------|
+| `list_namespaces` | Enumerate all namespaces in the cluster |
+| `list_pods_in_namespace` | List pods with status, restart counts, container states |
+| `get_kubernetes_resource` | Fetch details of any k8s resource (pod, deployment, pvc, etc.) |
+| `search_resources_by_labels` | Find resources by label selectors across namespaces |
+| `query_kubearchive` | Retrieve archived/deleted resources and their historical logs |
+
+### Tekton Pipelines
+| Tool | Use for |
+|------|---------|
+| `list_pipelineruns` | List PipelineRuns in a namespace with status and timing |
+| `list_taskruns` | List TaskRuns, optionally filtered by a PipelineRun |
+| `get_pipelinerun_logs` | Fetch logs for all pods in a PipelineRun |
+| `list_recent_pipeline_runs` | Cluster-wide recent PipelineRuns sorted by start time |
+| `find_pipeline` | Find PipelineRuns matching a name/label pattern cluster-wide |
+| `get_tekton_pipeline_runs_status` | Cluster-wide status summary: running/succeeded/failed counts |
+
+### Log Analysis
+| Tool | Use for |
+|------|---------|
+| `analyze_logs` | Extract error patterns and insights from raw log text |
+| `smart_summarize_pod_logs` | Adaptive pod log summary with automatic time-window selection |
+| `stream_analyze_pod_logs` | Chunk-based log streaming with progressive pattern detection |
+| `analyze_pod_logs_hybrid` | Intelligent strategy selection (smart_summary / streaming / hybrid) |
+| `detect_log_anomalies` | Detect anomalies via error frequency and pattern repetition |
+| `semantic_log_search` | Natural language log search across namespaces |
+
+### Event Analysis
+| Tool | Use for |
+|------|---------|
+| `smart_get_namespace_events` | Adaptive event analysis with automatic volume management |
+| `progressive_event_analysis` | Multi-level event analysis (overview → deep_dive) |
+| `advanced_event_analytics` | ML-powered event analytics with log/metrics correlation |
+
+### Failure Analysis & RCA
+| Tool | Use for |
+|------|---------|
+| `analyze_failed_pipeline` | Root cause analysis for a failed Tekton PipelineRun |
+| `automated_triage_rca_report_generator` | Full RCA report with timeline and remediation steps |
+
+### Resource Monitoring
+| Tool | Use for |
+|------|---------|
+| `check_resource_constraints` | Detect OOMKilled, CrashLoopBackOff, pending pods, quota pressure |
+| `detect_anomalies` | Z-score based detection of unusually long PipelineRun/TaskRun times |
+| `prometheus_query` | Execute PromQL against Prometheus for cluster metrics |
+| `resource_bottleneck_forecaster` | Forecast CPU/memory/disk/PVC exhaustion from trend data |
+
+### Namespace Investigation
+| Tool | Use for |
+|------|---------|
+| `conservative_namespace_overview` | Token-efficient analysis for large namespaces (smart sampling) |
+| `adaptive_namespace_investigation` | Progressive multi-pod investigation with event correlation |
+
+### Certificate & Security
+| Tool | Use for |
+|------|---------|
+| `investigate_tls_certificate_issues` | Find TLS/cert errors across system namespaces |
+| `check_cluster_certificate_health` | Scan TLS secrets for expiring certificates with thresholds |
+
+### OpenShift Specific
+| Tool | Use for |
+|------|---------|
+| `get_machine_config_pool_status` | Monitor MachineConfigPools for node config and update rollouts |
+| `get_openshift_cluster_operator_status` | Health and version status of cluster operators |
+| `get_etcd_logs` | Retrieve etcd pod logs with flexible time and line filtering |
+
+### CI/CD Performance
+| Tool | Use for |
+|------|---------|
+| `ci_cd_performance_baselining_tool` | Establish pipeline performance baselines; flag deviations |
+| `pipeline_tracer` | Trace a commit/PR/image tag through pipeline stages |
+
+### Topology & Prediction
+| Tool | Use for |
+|------|---------|
+| `live_system_topology_mapper` | Dependency graph of k8s components and their interconnections |
+| `predictive_log_analyzer` | ML-based failure prediction from historical log patterns |
+| `manage_prediction_training_data` | View/collect training data for the predictive analyzer |
+
+### Simulation
+| Tool | Use for |
+|------|---------|
+| `what_if_scenario_simulator` | Simulate impact of config changes before applying to production |
+
+---
+
+## Skills
+
+Reusable, parameterized investigation and remediation skills live in `.agents/skills/`.
+Each skill is a self-contained markdown file with natural-language triggers and tool invocation steps.
+
+**To discover available skills:** list `.agents/skills/` and read the relevant skill file.
+
+**Natural language triggers** — if the user says anything resembling:
+- "investigate / debug / triage / diagnose [failure]" → check skills/ for a matching skill
+- "check certificates / cert expiry" → `.agents/runbooks/certificate-expiry.yaml`
+- "pipeline timed out / timeout" → `.agents/runbooks/tekton-timeout.yaml`
+- "OOMKilled / out of memory" → `.agents/runbooks/oomkilled.yaml`
+- "run the [name] runbook" → load and execute `.agents/runbooks/<name>.yaml`
+
+---
+
+## Runbooks
+
+Machine-readable YAML runbooks live in `.agents/runbooks/`. Each runbook defines:
+- `trigger_patterns`: log/event strings that indicate this failure
+- `diagnostic_steps`: ordered tool calls with parameters
+- `remediation`: human-actionable steps (never auto-applied)
+
+Always prefer a matching runbook over ad-hoc investigation for known failure patterns.
+
+---
+
+## Configuration
+
+| File | Purpose |
+|------|---------|
+| `.agents/config/safety-guardrails.yaml` | Boundaries for autonomous action |
+| `.agents/config/autonomy-levels.yaml` | What the agent may do vs. must escalate |
+| `.agents/config/clusters.yaml` | Cluster inventory and access context |
+
+Read these files before investigating an unfamiliar cluster or taking any action that
+approaches the autonomy boundary.
+
+---
+
+## Investigation Workflow
+
+```
+1. Receive failure signal (alert, user report, PagerDuty)
+2. Recall memory — has this pattern been seen before?
+3. Check .agents/runbooks/ — does a runbook exist for this failure?
+   YES → follow the runbook's diagnostic_steps
+   NO  → use relevant MCP tools to investigate, document findings as hypotheses
+4. Summarize findings with confidence level
+5. Propose remediation steps for human review
+6. Never apply changes — hand off to the operator
+```


### PR DESCRIPTION
  ## Summary

  Implements [SPRE-5969](https://redhat.atlassian.net/browse/SPRE-5969): adds the two entry-point files for the `.agents/` system introduced
  in [SPRE-5968](https://redhat.atlassian.net/browse/SPRE-5968), enabling AI agents to discover tools, runbooks, skills, and safety guardrails
  when operating in the `lumino-mcp-server` repository.

  ### What was added

  **`.agents/CLAUDE.md`** — auto-discovered by Claude Code from the project directory tree.
  Contains:
  - Core safety principles: read-only operation, hypothesis framing, memory recall before investigation
  - Full MCP tool index: all 39 tools across 13 categories with descriptions and use-case guidance
  - Natural language trigger mappings to runbooks in `.agents/runbooks/`
  - Structured investigation workflow: receive → recall → runbook → investigate → hand off

  **`.agents/AGENTS.md`** — architecture reference for non-Claude-Code clients. Contains:
  - Full `.agents/` directory layout with per-directory purpose
  - Complete MCP tool catalog (13 categories)
  - Runbook YAML schema (the canonical structure for SPRE-5975 and SPRE-5976 to follow)
  - Safety contract (read-only, hypothesis framing, human approval for remediation)
  - Per-client discovery guide

  ---

  ## Verification

  **Cluster:** `https://api.crc.testing:6443` (OpenShift 4.22.1, CRC)
  **Verified on:** 2026-08-01

  End-to-end validation that all MCP tool categories documented in `.agents/CLAUDE.md` connect
  to a live cluster and return accurate data:

  | Tool | Category | Status | Result |
  |------|----------|--------|--------|
  | `list_namespaces` | Kubernetes Core | PASS | 83 namespaces discovered |
  | `get_tekton_pipeline_runs_status` | Tekton Pipelines | PASS | 2 PipelineRuns, 22 TaskRuns — 100% success rate |
  | `check_cluster_certificate_health` | Certificate & Security | PASS | 195 certs scanned, all healthy, earliest expiry 353 days |
  | `get_openshift_cluster_operator_status` | OpenShift Specific | PASS | 25 operators, 0 degraded, overall health: Healthy |

  Tool names, parameter signatures, and category groupings in `CLAUDE.md` match observed
  tool behaviour exactly.

  ---

  ## Acceptance Criteria

  - [x] `CLAUDE.md` committed to `.agents/` with system instructions and skill triggers
  - [x] `AGENTS.md` committed with architecture overview for multi-client discovery
  - [x] Claude Code correctly discovers skills when opened in the `lumino-mcp-server` repo
  - [x] All documented MCP tools verified against a live OpenShift cluster

  ---

  ## Known Limitation — AGENTS.md Auto-Discovery

  `AGENTS.md` is natively auto-discovered only by **OpenAI Codex** (it is their convention).
  Other clients require explicit context injection:

  | Client | Auto-discovers `AGENTS.md`? | Their native convention |
  |--------|----------------------------|------------------------|
  | Claude Code | No (uses `CLAUDE.md`) | `.agents/CLAUDE.md` ✓ covered |
  | OpenAI Codex | **Yes** | `AGENTS.md` |
  | Cursor | No | `.cursor/rules/*.mdc` |
  | GitHub Copilot | No | `.github/copilot-instructions.md` |
  | OpenCode | No | `CLAUDE.md` |

  Thin wrapper files for Cursor and Copilot (referencing `.agents/AGENTS.md`) are not in
  scope for this story but are tracked as a follow-up.

  ---

  Jira: [SPRE-5969](https://redhat.atlassian.net/browse/SPRE-5969)