### PR TITLE
feat: add crashloopbackoff runbook and test fixture

### DIFF
--- a/.agents/runbooks/crashloopbackoff.yaml
+++ b/.agents/runbooks/crashloopbackoff.yaml
@@ -41,7 +41,10 @@ spec:
     - tool: lumino.smart_get_namespace_events
       args:
         namespace: "{{ namespace }}"
-        time_period: "1h"
+        # Prefer last_n_events over time_period. Live kind validation (SPRE-5971)
+        # showed time_period="1h" can filter out all recent events (0 of N) while
+        # last_n_events / adaptive mode correctly returns BackOff warnings.
+        last_n_events: 50
         focus_areas: ["errors", "warnings", "failures"]
       extract: ["events", "insights", "recommendations"]
     - tool: lumino.smart_summarize_pod_logs
@@ -51,12 +54,15 @@ spec:
         container_name: "{{ container }}"
         summary_level: "detailed"
         focus_areas: ["errors", "warnings"]
-        time_period: "1h"
-      extract: ["insights", "patterns", "recommendations"]
+        tail_lines: 200
+      extract: ["insights", "patterns", "recommendations", "metadata"]
       # smart_summarize_pod_logs has no `previous` arg (verified in MCP schema /
       # server-mcp.py). Previous-instance logs are available on get_pipelinerun_logs
       # and get_etcd_logs only. If current-container output is empty, rely on
       # get_kubernetes_resource lastState + events, and note the Lumino gap.
+      # Pattern extraction may report 0 matches for plain stderr without
+      # error/warning keywords — still inspect metadata.processing_metrics and
+      # any returned samples / raw lines for messages like "not found".
       on_failure: skip
   analysis:
     compare:

--- a/.agents/runbooks/crashloopbackoff.yaml
+++ b/.agents/runbooks/crashloopbackoff.yaml
@@ -1,0 +1,94 @@
+# CrashLoopBackOff runbook — SPRE-5971
+# Schema: design spec §5.2 (spre.agents/v1 Runbook)
+# Pattern: design spec §3.2 pattern #3
+# Tools verified against lumino-mcp-server MCP signatures
+apiVersion: spre.agents/v1
+kind: Runbook
+metadata:
+  name: crashloopbackoff
+  description: "Container repeatedly crashes on startup and Kubernetes backs off restarting it"
+  failure_type: CrashLoopBackOff
+spec:
+  trigger:
+    # String match against error/status/log text (§3.2: simple string matching).
+    # Do NOT use bare "BackOff" — that also matches ImagePullBackOff (pattern #2).
+    patterns:
+      - "CrashLoopBackOff"
+      - "Back-off restarting failed container"
+      - "Liveness probe failed"
+      - "Startup probe failed"
+    # Waiting-reason / status signals distinct from ImagePullBackOff / ErrImagePull.
+    events:
+      - "CrashLoopBackOff"
+    # Common terminated exit codes for crash loops (exclude 137 — that is oomkilled).
+    # 126/127: shell/Docker convention — command not executable / not found.
+    exit_codes: [1, 126, 127, 139]
+  diagnostic_steps:
+    # §3.2 prescribed tools: list_pods_in_namespace, smart_summarize_pod_logs.
+    # get_kubernetes_resource + smart_get_namespace_events added from SOP practice
+    # (oc describe / events) with params verified against Lumino MCP schemas.
+    - tool: lumino.list_pods_in_namespace
+      args:
+        namespace: "{{ namespace }}"
+      extract: ["name", "status", "restart_count", "container_states", "node_name", "creation_timestamp"]
+    - tool: lumino.get_kubernetes_resource
+      args:
+        resource_type: "pod"
+        name: "{{ pod }}"
+        namespace: "{{ namespace }}"
+        output_format: "detailed"
+      extract: ["status", "lastState", "exitCode", "reason", "message", "volumeMounts", "env"]
+    - tool: lumino.smart_get_namespace_events
+      args:
+        namespace: "{{ namespace }}"
+        time_period: "1h"
+        focus_areas: ["errors", "warnings", "failures"]
+      extract: ["events", "insights", "recommendations"]
+    - tool: lumino.smart_summarize_pod_logs
+      args:
+        namespace: "{{ namespace }}"
+        pod_name: "{{ pod }}"
+        container_name: "{{ container }}"
+        summary_level: "detailed"
+        focus_areas: ["errors", "warnings"]
+        time_period: "1h"
+      extract: ["insights", "patterns", "recommendations"]
+      # smart_summarize_pod_logs has no `previous` arg (verified in MCP schema /
+      # server-mcp.py). Previous-instance logs are available on get_pipelinerun_logs
+      # and get_etcd_logs only. If current-container output is empty, rely on
+      # get_kubernetes_resource lastState + events, and note the Lumino gap.
+      on_failure: skip
+  analysis:
+    compare:
+      - "restart_count vs peer pods in the same Deployment/StatefulSet"
+      - "lastState.terminated.exitCode vs known meanings (1=app error, 126=command found but not executable, 127=command not found, 137=OOM → hand off to oomkilled runbook, 139=segfault)"
+      - "container waiting reason CrashLoopBackOff vs ImagePullBackOff / ErrImagePull (different runbook)"
+    check:
+      - "Which pods are in CrashLoopBackOff and what are their restart counts?"
+      - "What exit code and termination reason appear in lastState.terminated?"
+      - "Are current-container logs empty because the process just restarted or is in backoff wait? If so, lastState + events are the primary signal until previous-instance log support exists on smart_summarize_pod_logs."
+      - "Do logs show missing ConfigMap/Secret, bad args, panic, auth failure, or dependency unreachable?"
+      - "Are required volumes/env refs present (configMapRef / secretRef) on the pod spec?"
+      - "Did CrashLoopBackOff start after a recent deploy, ConfigMap, or Secret change (correlate with events)?"
+      - "Is this OOM (exit 137 / reason OOMKilled) rather than a true startup crash — if so, switch to the oomkilled runbook?"
+      - "Are liveness or startup probe failures killing the container? (Readiness probe failures remove endpoints only and do not restart containers.)"
+  remediation:
+    - "Fix the application startup error identified in logs (bad config, missing dependency, panic)"
+    - "Restore or create missing ConfigMaps/Secrets referenced by the workload; verify ArgoCD/GitOps sync if managed"
+    - "Roll back a bad deployment or config change that introduced the crash loop"
+    - "Correct command/args or image so the process can start (exit 126 not-executable / 127 not-found)"
+    - "If exit code 137 or reason OOMKilled, follow the oomkilled runbook instead of CrashLoop-only fixes"
+    - "Adjust misconfigured liveness or startup probes that kill a still-starting container"
+  verification:
+    - "Rerun list_pods_in_namespace and confirm no pods remain in CrashLoopBackOff"
+    - "Confirm restart_count stabilizes (no further increments over several minutes)"
+    - "Rerun smart_summarize_pod_logs and confirm prior fatal/error patterns are gone"
+    - "Confirm related Warning events for Back-off restarting / CrashLoopBackOff stop appearing in smart_get_namespace_events"
+  rollback:
+    - "If a config or image change was applied during remediation and the crash worsens, roll back the Deployment/StatefulSet to the last known-good revision"
+    - "Restore previous ConfigMap/Secret versions from GitOps if the change was synced via ArgoCD"
+  escalation:
+    # Generic CrashLoop SOP: escalate by namespace ownership when unresolved.
+    # Service-specific SOPs (e.g. TektonKueue) may name a fixed Slack channel.
+    condition: "CrashLoopBackOff persists after diagnostic steps with no clear root cause, or the fix requires application/code changes outside SRE control"
+    target: "Owning application team for the alert namespace (see Application Team Contact List); for shared infra namespaces escalate to the relevant platform/infra forum"

--- a/.agents/tests/fixtures/crashloopbackoff-test.yaml
+++ b/.agents/tests/fixtures/crashloopbackoff-test.yaml
@@ -1,0 +1,59 @@
+# Test fixture for the crashloopbackoff runbook (SPRE-5971).
+#
+# Creates a Deployment whose container always exits immediately (exit 1),
+# producing a deterministic CrashLoopBackOff under the Deployment default
+# restartPolicy of Always (Kubernetes Pod lifecycle).
+#
+# Cycle timing is dominated by kubelet restart backoff (10s, 20s, 40s, …
+# capped at 300s), not terminationGracePeriodSeconds — do not expect a
+# faster loop from lowering the grace period for an immediate exit 1.
+#
+# Apply:    oc apply -f crashloopbackoff-test.yaml
+# Watch:    oc get pods -n spre-crashloop-test -w
+# Diagnose: run crashloopbackoff diagnostic_steps with
+#           namespace=spre-crashloop-test and the crashing pod name.
+# Cleanup:  oc delete -f crashloopbackoff-test.yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spre-crashloop-test
+  labels:
+    purpose: spre-runbook-testing
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: intentional-crash
+  namespace: spre-crashloop-test
+  labels:
+    app: intentional-crash
+    purpose: spre-runbook-testing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: intentional-crash
+  template:
+    metadata:
+      labels:
+        app: intentional-crash
+    spec:
+      containers:
+        - name: crash
+          # UBI minimal is available on RHEL-based OCP clusters without
+          # additional registry config (same approach as tekton-timeout fixture).
+          image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "intentional crash for crashloopbackoff runbook test" >&2
+              echo "simulating missing config: configmap \"app-config\" not found" >&2
+              exit 1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi


### PR DESCRIPTION
Implements [SPRE-5971](https://redhat.atlassian.net/browse/SPRE-5971): machine-readable YAML runbook for CrashLoopBackOff failures, following the `spre.agents/v1` schema from the design specification (§3.2 / §5.2) and the same structure as the tekton-timeout runbook ([#174](https://github.com/spre-sre/lumino-mcp-server/pull/174)).

---

## What was added

### `.agents/runbooks/crashloopbackoff.yaml`

Runbook for `CrashLoopBackOff` failure patterns. Includes trigger patterns/events/exit codes, four ordered diagnostic steps, analysis checks, remediation, verification, rollback, and escalation.

**Diagnostic steps (in order):**

| # | Tool | Purpose |
|---|------|---------|
| 1 | `lumino.list_pods_in_namespace` | Identify CrashLoopBackOff pods, restart counts, and container waiting reasons |
| 2 | `lumino.get_kubernetes_resource` | Inspect exit code / `lastState` / mounts for the crashing pod |
| 3 | `lumino.smart_get_namespace_events` | Correlate Back-off / probe / config events (`last_n_events`) |
| 4 | `lumino.smart_summarize_pod_logs` | Summarize startup errors (missing config, panic, auth, dependency failures) |

### `.agents/tests/fixtures/crashloopbackoff-test.yaml`

Self-contained fixture that produces a deterministic CrashLoopBackOff:

- `Namespace` — `spre-crashloop-test`
- `Deployment` — `intentional-crash` (UBI minimal, `exit 1`, simulated missing ConfigMap log line)

Apply with `kubectl apply -f .agents/tests/fixtures/crashloopbackoff-test.yaml`, then run the runbook diagnostic steps against `namespace=spre-crashloop-test`.

---

## Live cluster validation — kind `konflux` (Kubernetes v1.35.0)

All four diagnostic steps executed against a live kind cluster via the lumino MCP server tools (local invocation with `kind-konflux` context).

| Step | Tool | Status | Result |
|------|------|--------|--------|
| 1 | `list_pods_in_namespace` | ✅ PASS | Pod `intentional-crash-…` with `container_states: ["CrashLoopBackOff"]`, `restart_count: 4` |
| 2 | `get_kubernetes_resource` | ✅ PASS | `lastState.terminated.exitCode=1`, waiting reason `CrashLoopBackOff`, backoff message present |
| 3 | `smart_get_namespace_events` | ✅ PASS (after fix) | With `last_n_events` / adaptive mode: Warning `BackOff` — `Back-off restarting failed container crash…` |
| 4 | `smart_summarize_pod_logs` | ✅ PASS | Retrieved fixture stderr lines (`intentional crash…`, `configmap "app-config" not found`); keyword pattern matcher reported 0 matches (plain stderr without error/warning tokens) |

**Notable finding — Step 3:** `time_period: "1h"` filtered **all** events to 0 (tool fetched 12–13 events, then dropped them). Omitting `time_period` (adaptive) or using `last_n_events: 50` correctly returned the `BackOff` warnings. Runbook updated accordingly.

**Notable finding — Step 4:** `smart_summarize_pod_logs` has **no `previous` param** (unlike `get_pipelinerun_logs` / `get_etcd_logs`). Current-container logs were available for this fixture; pattern extraction may still report 0 matches for plain stderr — analysis should inspect returned lines/metadata, not only `patterns`.

---

## Corrections made during live testing

- **`smart_get_namespace_events` args changed from `time_period: 1h` → `last_n_events: 50`** — discovered via kind observation
- **`smart_summarize_pod_logs` uses `tail_lines: 200`** instead of `time_period: 1h`; notes added about empty pattern matches and missing `previous` support
- Trigger patterns already avoided bare `"BackOff"` to prevent ImagePullBackOff false matches (confirmed still correct)

---

## Test plan

- [x] Apply fixture on kind; confirm CrashLoopBackOff + exit code 1
- [x] Exercise diagnostic steps 1–4 via Lumino tools against kind
- [x] Update runbook from live findings (events filter)
- [ ] Review YAML against design spec §5.2 (`apiVersion: spre.agents/v1`, `kind: Runbook`)
- [ ] Confirm trigger patterns do not incorrectly match ImagePullBackOff-only failures

Jira: [SPRE-5971](https://redhat.atlassian.net/browse/SPRE-5971)