### PR TITLE
feat: Add Devlake DORA metrics baseline (SPRE-5967)

### DIFF
--- a/baselines/devlake/devlake_dora_baseline_metrics.json
+++ b/baselines/devlake/devlake_dora_baseline_metrics.json
@@ -1,0 +1,172 @@
+{
+  "metadata": {
+    "description": "DORA metrics baseline for SPRE-managed Konflux projects from DevLake",
+    "period": {
+      "since": "2026-02-19",
+      "until": "2026-08-19"
+    },
+    "projects_analyzed": [
+      "Secureflow - Konflux - Global",
+      "Secureflow - Konflux - Infrastructure Team"
+    ],
+    "extracted_at": "2026-08-19T15:56:00Z"
+  },
+  "deployment_frequency": {
+    "konflux_global": {
+      "total_deployments": 649,
+      "unique_deployment_days": 134,
+      "period_days": 181,
+      "avg_deployments_per_week": 24.04,
+      "avg_deployment_days_per_week": 4.96,
+      "dora_level": "High",
+      "by_month": {
+        "2026-02": { "deployment_days": 6, "total_deployments": 62 },
+        "2026-03": { "deployment_days": 26, "total_deployments": 258 },
+        "2026-04": { "deployment_days": 25, "total_deployments": 128 },
+        "2026-05": { "deployment_days": 19, "total_deployments": 41 },
+        "2026-06": { "deployment_days": 23, "total_deployments": 68 },
+        "2026-07": { "deployment_days": 22, "total_deployments": 65 },
+        "2026-08": { "deployment_days": 13, "total_deployments": 27 }
+      }
+    },
+    "konflux_infrastructure": {
+      "total_deployments": 406,
+      "unique_deployment_days": 87,
+      "period_days": 181,
+      "avg_deployments_per_week": 15.62,
+      "avg_deployment_days_per_week": 3.35,
+      "dora_level": "High",
+      "by_month": {
+        "2026-02": { "deployment_days": 6, "total_deployments": 51 },
+        "2026-03": { "deployment_days": 26, "total_deployments": 212 },
+        "2026-04": { "deployment_days": 19, "total_deployments": 92 },
+        "2026-05": { "deployment_days": 7, "total_deployments": 9 },
+        "2026-06": { "deployment_days": 11, "total_deployments": 16 },
+        "2026-07": { "deployment_days": 12, "total_deployments": 18 },
+        "2026-08": { "deployment_days": 6, "total_deployments": 8 }
+      }
+    }
+  },
+  "lead_time_for_changes": {
+    "project": "Secureflow - Konflux - Infrastructure Team",
+    "deployed_prs_count": 1541,
+    "avg_lead_time_hours": 1345.47,
+    "avg_lead_time_human": "56.1 days",
+    "dora_level": "Low",
+    "breakdown": {
+      "avg_coding_time_hours": 10.04,
+      "avg_pickup_time_hours": 16.1,
+      "avg_review_time_hours": 45.15,
+      "avg_deploy_time_hours": 1227.91
+    },
+    "breakdown_human": {
+      "avg_coding_time": "10.0 hours",
+      "avg_pickup_time": "16.1 hours",
+      "avg_review_time": "1.9 days",
+      "avg_deploy_time": "51.2 days"
+    },
+    "note": "Lead time is heavily dominated by deploy_time (51.2 days avg), which measures time from PR merge to production deployment. Coding + review + pickup together average only 71.3 hours (3 days)."
+  },
+  "pr_cycle_time": {
+    "project": "Secureflow - Konflux - Infrastructure Team",
+    "merged_pr_count": 2906,
+    "avg_cycle_time_hours": 98.34,
+    "avg_cycle_time_human": "4.1 days",
+    "breakdown": {
+      "avg_coding_time_hours": 11.10,
+      "avg_pickup_time_hours": 21.89,
+      "avg_review_time_hours": 39.93
+    },
+    "breakdown_human": {
+      "avg_coding_time": "11.1 hours",
+      "avg_pickup_time": "21.9 hours",
+      "avg_review_time": "1.7 days"
+    },
+    "by_pr_size": [
+      { "size": "XS (1-50 lines)", "pr_count": 2320, "avg_cycle_time_hours": 87.06, "avg_pickup_hours": 21.76, "avg_review_hours": 31.65 },
+      { "size": "S (51-200 lines)", "pr_count": 332, "avg_cycle_time_hours": 119.77, "avg_pickup_hours": 22.82, "avg_review_hours": 60.11 },
+      { "size": "M (201-500 lines)", "pr_count": 143, "avg_cycle_time_hours": 149.93, "avg_pickup_hours": 19.29, "avg_review_hours": 91.70 },
+      { "size": "L (501-1000 lines)", "pr_count": 59, "avg_cycle_time_hours": 246.58, "avg_pickup_hours": 25.52, "avg_review_hours": 80.65 },
+      { "size": "XL (>1000 lines)", "pr_count": 52, "avg_cycle_time_hours": 149.34, "avg_pickup_hours": 24.55, "avg_review_hours": 87.05 }
+    ],
+    "top_repos": [
+      { "repo": "redhat-appstudio/infra-deployments", "merged_prs": 1565, "avg_cycle_time_hours": 73.64 },
+      { "repo": "redhat-appstudio/infra-common-deployments", "merged_prs": 453, "avg_cycle_time_hours": 38.56 },
+      { "repo": "konflux-ci/namespace-lister", "merged_prs": 140, "avg_cycle_time_hours": 100.92 },
+      { "repo": "konflux-ci/oauth2-proxy", "merged_prs": 132, "avg_cycle_time_hours": 33.64 },
+      { "repo": "konflux-ci/tekton-kueue", "merged_prs": 121, "avg_cycle_time_hours": 379.17 },
+      { "repo": "konflux-ci/may", "merged_prs": 110, "avg_cycle_time_hours": 83.53 },
+      { "repo": "konflux-ci/multi-platform-controller", "merged_prs": 101, "avg_cycle_time_hours": 469.63 },
+      { "repo": "konflux-ci/etcd-shield", "merged_prs": 82, "avg_cycle_time_hours": 243.56 }
+    ]
+  },
+  "pr_stats": {
+    "project": "Secureflow - Konflux - Infrastructure Team",
+    "total_prs": 4766,
+    "merged_prs": 2794,
+    "open_prs": 250,
+    "closed_prs": 1722,
+    "merge_rate_pct": 58.6,
+    "stale_prs_14d": 168,
+    "by_type": {
+      "engineering": { "total": 3722, "merged": 2150, "open": 166, "merge_rate_pct": 57.8 },
+      "dependency_bot": { "total": 1021, "merged": 644, "open": 79, "merge_rate_pct": 63.1 }
+    }
+  },
+  "dora_benchmark_comparison": {
+    "deployment_frequency": {
+      "current": "4.96 days/week (Global), 3.35 days/week (Infra)",
+      "dora_level": "High",
+      "benchmark": {
+        "elite": ">= 5 days/week (on-demand, multiple per day)",
+        "high": ">= 1 day/week",
+        "medium": ">= 1 day/month",
+        "low": "< 1 day/month"
+      }
+    },
+    "lead_time_for_changes": {
+      "current": "56.1 days (end-to-end), 3.0 days (code-to-merge)",
+      "dora_level": "Low (end-to-end) / High (code-to-merge)",
+      "benchmark": {
+        "elite": "< 1 hour",
+        "high": "1 day - 1 week",
+        "medium": "1 - 6 months",
+        "low": "> 6 months"
+      },
+      "note": "The 51.2-day avg deploy time dominates. Code-to-merge (3 days) is High-tier."
+    },
+    "change_failure_rate": {
+      "current_pct": 0.15,
+      "dora_level": "Elite",
+      "total_production_deployments": 1992,
+      "successful_deployments": 1989,
+      "failed_deployments": 3,
+      "method": "Direct from DevLake production deployment outcomes (SUCCESS vs FAILURE) for all Secureflow - Konflux projects",
+      "by_month": {
+        "2026-02": { "successful": 186, "failed": 0, "total": 186, "cfr_pct": 0.0 },
+        "2026-03": { "successful": 798, "failed": 0, "total": 798, "cfr_pct": 0.0 },
+        "2026-04": { "successful": 393, "failed": 3, "total": 396, "cfr_pct": 0.8 },
+        "2026-05": { "successful": 129, "failed": 0, "total": 129, "cfr_pct": 0.0 },
+        "2026-06": { "successful": 189, "failed": 0, "total": 189, "cfr_pct": 0.0 },
+        "2026-07": { "successful": 204, "failed": 0, "total": 204, "cfr_pct": 0.0 },
+        "2026-08": { "successful": 90, "failed": 0, "total": 90, "cfr_pct": 0.0 }
+      },
+      "benchmark": {
+        "elite": "< 5%",
+        "high": "6-15%",
+        "medium": "16-30%",
+        "low": "> 30%"
+      }
+    },
+    "mttr": {
+      "current": "25.1 minutes (median), from SPRE-5966 PagerDuty baseline",
+      "dora_level": "Elite",
+      "benchmark": {
+        "elite": "< 1 hour",
+        "high": "< 1 day",
+        "medium": "1 day - 1 week",
+        "low": "> 1 week"
+      }
+    }
+  }
+}

--- a/baselines/devlake/devlake_dora_baseline_report.md
+++ b/baselines/devlake/devlake_dora_baseline_report.md
@@ -1,0 +1,168 @@
+# Devlake DORA Metrics Baseline Report
+
+<!-- **Ticket:** [SPRE-5967](https://redhat.atlassian.net/browse/SPRE-5967)
+**Epic:** [SPRE-5901](https://redhat.atlassian.net/browse/SPRE-5901) —   --> Agentic AI Workflows for SPRE 
+**Period:** 2026-02-19 to 2026-08-19 (6 months) <br>
+**Projects:** Secureflow - Konflux - Global, Secureflow - Konflux - Infrastructure Team
+**Generated:** 2026-08-19
+
+---
+
+## DORA Metrics vs Industry Benchmarks
+
+| DORA Metric | Current Value | DORA Level | Elite Benchmark |
+|-------------|---------------|------------|-----------------|
+| **Deployment Frequency** | 4.96 days/week (Global) | **High** | >= 5 days/week |
+| **Lead Time for Changes** | 3.0 days (code-to-merge) | **High** | < 1 hour |
+| **Lead Time (end-to-end)** | 56.1 days (merge-to-prod) | **Low** | < 1 hour |
+| **Change Failure Rate** | 0.15% (3 failures / 1,992 prod deploys) | **Elite** | < 5% |
+| **MTTR** | 25.1 min median (from SPRE-5966) | **Elite** | < 1 hour |
+
+---
+
+## 1. Deployment Frequency
+
+### Konflux Global
+| Metric | Value |
+|--------|-------|
+| Total deployments | 649 |
+| Unique deployment days | 134 / 181 days |
+| Avg deployments/week | 24.0 |
+| Avg deployment days/week | **4.96** |
+| **DORA Level** | **High** (just below Elite threshold of 5) |
+
+### Konflux Infrastructure Team
+| Metric | Value |
+|--------|-------|
+| Total deployments | 406 |
+| Unique deployment days | 87 / 181 days |
+| Avg deployments/week | 15.6 |
+| Avg deployment days/week | **3.35** |
+| **DORA Level** | **High** |
+
+### Monthly Deployment Trend
+
+| Month | Global Deploys | Infra Deploys | Global Days | Infra Days |
+|-------|---------------|---------------|-------------|------------|
+| Feb 2026 | 62 | 51 | 6 | 6 |
+| Mar 2026 | 258 | 212 | 26 | 26 |
+| Apr 2026 | 128 | 92 | 25 | 19 |
+| May 2026 | 41 | 9 | 19 | 7 |
+| Jun 2026 | 68 | 16 | 23 | 11 |
+| Jul 2026 | 65 | 18 | 22 | 12 |
+| Aug 2026 | 27 | 8 | 13 | 6 |
+
+Deployment volume peaked in March and dropped significantly from May onward, especially for the Infrastructure team.
+
+---
+
+## 2. Lead Time for Changes
+
+| Breakdown | Avg Hours | Human |
+|-----------|-----------|-------|
+| Coding time | 10.0 | 10 hours |
+| Pickup time (PR submitted → 1st review) | 16.1 | 16 hours |
+| Review time (1st review → merged) | 45.2 | 1.9 days |
+| Code-to-merge subtotal | 71.3| 3.0 days |
+| Deploy time (merged → production) | 1,227.9 | 51.2 days |
+| **Total lead time** | **1,345.5** | **56.1 days** |
+
+**Key insight:** The code-to-merge pipeline (3 days) rates as **DORA High**. However, the merge-to-production deploy time (51.2 days) drags the overall lead time to **DORA Low**. This deploy lag is the single biggest opportunity for improvement.
+
+---
+
+## 3. PR Cycle Time
+
+Based on 2,906 merged PRs in the Infrastructure Team.
+
+| Metric | Value |
+|--------|-------|
+| Avg total cycle time | 4.1 days (98.3 hours) |
+| Avg coding time | 11.1 hours |
+| Avg pickup time | 21.9 hours |
+| Avg review time | 1.7 days (39.9 hours) |
+
+### Cycle Time by PR Size
+
+| Size | PR Count | Avg Cycle Time | Avg Review Time |
+|------|----------|---------------|-----------------|
+| XS (1-50 lines) | 2,320 | 3.6 days | 1.3 days |
+| S (51-200 lines) | 332 | 5.0 days | 2.5 days |
+| M (201-500 lines) | 143 | 6.2 days | 3.8 days |
+| L (501-1000 lines) | 59 | 10.3 days | 3.4 days |
+| XL (>1000 lines) | 52 | 6.2 days | 3.6 days |
+
+Smaller PRs merge significantly faster. 80% of PRs are XS (< 50 lines), indicating good PR hygiene.
+
+### Top Repos by Cycle Time
+
+| Repository | Merged PRs | Avg Cycle Time |
+|------------|-----------|----------------|
+| infra-deployments | 1,565 | 3.1 days |
+| infra-common-deployments | 453 | 1.6 days |
+| namespace-lister | 140 | 4.2 days |
+| oauth2-proxy | 132 | 1.4 days |
+| tekton-kueue | 121 | 15.8 days |
+| multi-platform-controller | 101 | 19.6 days |
+| etcd-shield | 82 | 10.1 days |
+
+---
+
+## 4. PR Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total PRs (6 months) | 4,766 |
+| Merged | 2,794 (58.6%) |
+| Open | 250 |
+| Closed (not merged) | 1,722 |
+| Stale (> 14 days) | 168 |
+| Engineering PRs | 3,722 (57.8% merge rate) |
+| Dependency bot PRs | 1,021 (63.1% merge rate) |
+
+---
+
+## 5. Change Failure Rate
+
+Computed directly from DevLake production deployment outcomes (SUCCESS vs FAILURE) for all Secureflow - Konflux projects.
+
+| Month | Successful | Failed | Total | CFR |
+|-------|-----------|--------|-------|-----|
+| Feb 2026 | 186 | 0 | 186 | 0.0% |
+| Mar 2026 | 798 | 0 | 798 | 0.0% |
+| Apr 2026 | 393 | 3 | 396 | 0.8% |
+| May 2026 | 129 | 0 | 129 | 0.0% |
+| Jun 2026 | 189 | 0 | 189 | 0.0% |
+| Jul 2026 | 204 | 0 | 204 | 0.0% |
+| Aug 2026 | 90 | 0 | 90 | 0.0% |
+| **Total** | **1,989** | **3** | **1,992** | **0.15%** |
+
+Only 3 production deployments failed in 6 months, all in April 2026.
+
+**DORA Level: Elite** (< 5%)
+
+---
+
+## Summary & Implications for Agentic AI (SPRE-5901)
+
+### Strengths
+- **MTTR is Elite-tier** (25.1 min median) — incidents resolve fast
+- **Deployment frequency is High-tier** (nearly 5 days/week globally) — the team ships regularly
+- **PR hygiene is good** — 80% of PRs are XS, and merge rates are healthy
+
+### Improvement Opportunities
+1. **Merge-to-production deploy lag (51.2 days)** — This is the dominant bottleneck. Agentic workflows could accelerate promotion through automated validation and staged rollout checks.
+2. **Review time (1.7 days avg)** — Agentic code review assistance could reduce pickup and review time, especially for the repos with 10-20 day cycle times (tekton-kueue, multi-platform-controller).
+3. **168 stale PRs** — Automated triage and nudging could reduce PR staleness.
+4. **Change failure rate is Elite** — Only 3 failed deployments in 6 months. Maintaining this as agentic workflows are introduced will be important.
+
+---
+
+## Deliverables
+
+| File | Description |
+|------|-------------|
+| `devlake_dora_baseline_metrics.json` | Structured JSON with all DORA metrics and benchmark comparison |
+| `devlake_dora_baseline_report.md` | This summary report |
+
+*This baseline supplements the PagerDuty baseline and together they form the foundation for measuring Agentic AI improvements.*


### PR DESCRIPTION
## Summary

- Extracted 6 months of DORA metrics from DevLake (Feb 19 - Aug 19, 2026) for Konflux Global and Infrastructure Team projects
- Computed deployment frequency, lead time for changes, PR cycle time, and change failure rate
- Generated structured JSON artifact and summary report with industry benchmark comparison

### DORA Scorecard

| Metric | Value | DORA Level |
|--------|-------|------------|
| Deployment Frequency | 4.96 days/week | **High** |
| Lead Time (code-to-merge) | 3.0 days | **High** |
| Lead Time (end-to-end) | 56.1 days | **Low** |
| Change Failure Rate | 0.15% (3/1,992 prod deploys) | **Elite** |
| MTTR | 25.1 min median | **Elite** (from SPRE-5966) |

### Files Added

- `baselines/devlake/devlake_dora_baseline_metrics.json` — Structured JSON with all DORA metrics and benchmark comparison
- `baselines/devlake/devlake_dora_baseline_report.md` — Summary report comparing current metrics against industry benchmarks

## Test plan

- [ ] Review metrics JSON for accuracy and completeness
- [ ] Verify DORA benchmark classifications match the data
- [ ] Confirm no sensitive data is present
- [ ] Validate alongside PagerDuty baseline (PR #181) for cross-reference accuracy